### PR TITLE
security: harden CDP/daemon/cookie surface (v0.11.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Dependencies
+node_modules/
+
+# Runtime session artifacts — may contain authenticated page snapshots,
+# saved state (cookies + localStorage = session tokens), screenshots, logs.
+.barebrowse/
+
+# Secrets / local env
+.env
+.env.*
+!.env.example
+
+# Editor / tooling
+.idea/
+.aurora/
+*.log
+
+# OS
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,69 @@
 # Changelog
 
+## 0.11.0
+
+### Security hardening — audit findings fixed, safe-by-default
+
+A full security audit of the library + CLI daemon + MCP server. Eight
+findings were reproduced with live PoCs, fixed, and locked in with 14 new
+regression tests (143 → 157 passing). Two new opt-in controls; two new
+defaults that change behavior (see **Breaking** below).
+
+- **Daemon authentication (was: unauthenticated `eval` over loopback).**
+  The CLI daemon's HTTP server bound to `127.0.0.1` but had no auth — and
+  loopback is shared across local users, so any local process could POST
+  `/command` (including `eval` = arbitrary JS in the authenticated browser).
+  Now every daemon mints a 32-byte random token at startup, written into
+  `session.json` (mode `0600`) and required on `/command` via the
+  `x-barebrowse-token` header (constant-time compare). `session-client.js`
+  reads and sends it transparently — no caller change. `GET /status` stays
+  open as a liveness ping returning only `{ ok, pid }`.
+- **Artifact permissions.** The session dir is now created `0700` and all
+  daemon artifacts (`session.json`, snapshots, screenshots, PDFs, console /
+  network / dialog logs) plus `page.saveState()` output are written `0600`.
+  `saveState` holds cookies + localStorage (session tokens), so this stops a
+  multi-user host from reading another user's credentials off disk.
+- **Navigation scheme guard (new module `src/url-guard.js`).** `goto()` /
+  `browse()` now reject local-resource and browser-internal schemes
+  (`file:`, `view-source:`, `chrome:`, `chrome-extension:`, `filesystem:`,
+  `devtools:`, …) by default — closing a confirmed local-file-read /
+  directory-listing vector for a prompt-injected agent. `http`/`https`/
+  `data`/`blob`/`about` stay allowed (`data:` is opaque-origin and the
+  test-fixture mechanism — not a read/SSRF vector). Override with
+  `{ allowLocalUrls: true }`.
+- **SSRF guard (opt-in `blockPrivateNetwork`).** When set, `goto()`/
+  `browse()` refuse loopback / RFC-1918 / link-local / cloud-metadata
+  (`169.254.169.254`) / `*.internal` hosts. Off by default so localhost
+  dev-server browsing keeps working. Exposed as `--block-private-network`.
+- **Upload sandbox (opt-in `uploadDir`).** `upload()` confirmed it would
+  attach any absolute path to a file input (exfil vector under prompt
+  injection). When `uploadDir` is set, every path must resolve (symlinks
+  included, via `realpath`) inside it. Default unrestricted — nothing breaks
+  unless you opt in. Exposed as `--upload-dir=DIR`. Both new opts pass
+  through `connect()` → MCP / bareagent / CLI daemon uniformly.
+- **Cookie injection scoped precisely (was: over-broad substring match).**
+  `authenticate()` matched `host_key LIKE '%domain%'`, so browsing
+  `apple.com` injected cookies for `apple.com.evil.org` / `notapple.com`,
+  and `mybank.co.uk` (→ `co.uk`) pulled every `*.co.uk` cookie. The LIKE
+  query is now only a coarse pre-filter; a precise RFC-6265
+  `cookieDomainMatch()` decides what actually gets injected (parent-domain
+  cookies like `.google.com` still apply to `mail.google.com`).
+- **Hardening:** browser discovery uses `execFileSync('which', [name])`
+  (no shell) instead of an interpolated `execSync` string; the cleanup
+  busy-wait drops a `sleep` subprocess for `Atomics.wait`. Added
+  `.gitignore` (was missing — `.barebrowse/` state/snapshots could be
+  accidentally committed). Pinned `wearehere` to exact `1.0.0`.
+- **Tests:** 157 total (14 new) — `test/unit/url-guard.test.js` (19
+  assertions over scheme/private-host policy), `cookieDomainMatch` cases in
+  `test/unit/auth.test.js`, daemon token + `0600` perms in
+  `test/integration/cli.test.js`.
+
+**Breaking:** (1) `file:`/`chrome:`/etc. navigation now throws by default —
+pass `allowLocalUrls: true` to restore. (2) The CLI daemon now requires the
+token; this is transparent via the bundled `session-client`, but any
+third-party client hitting the daemon's HTTP API directly must send
+`x-barebrowse-token` from `session.json`.
+
 ## 0.10.1
 
 ### Blocklist long-tail additions + legacy-Chrome warn + switchTab attach-mode test

--- a/README.md
+++ b/README.md
@@ -134,6 +134,17 @@ No clone profile, no fresh cookies — the agent sees what you see.
 
 Cookie consent walls (29 languages, with real mouse click fallback for stubborn CMPs), login walls (cookie extraction from your browsers), bot detection (ARIA node count heuristic + stealth patches + automatic headed fallback — snapshot shows `[BOT CHALLENGE DETECTED]` warning when blocked), permission prompts, SPA navigation, JS dialogs, off-screen elements, pre-filled inputs, ARIA noise, and profile locking. The agent doesn't think about any of it.
 
+## Safe by default (v0.11.0)
+
+barebrowse hands an autonomous — and therefore prompt-injectable — agent an *authenticated* browser, so the defaults are calibrated for that threat:
+
+- **Local-resource schemes blocked.** `file:`, `view-source:`, `chrome:`, etc. are rejected by default (a confirmed local-file-read vector); `http`/`https`/`data` stay allowed. Override with `allowLocalUrls: true`.
+- **Cookie injection scoped** to a precise RFC-6265 domain match — browsing one site can't pull look-alike or unrelated cookies into the session.
+- **CLI daemon authenticated** with a per-session token (loopback alone isn't an authorization boundary); snapshots and saved state are written owner-only (`0600`).
+- **Opt-in hardening** for stricter deployments: `blockPrivateNetwork` (SSRF guard for loopback/RFC-1918/cloud-metadata) and `uploadDir` (confine `upload()` to one directory). Both available on the library, MCP, bareagent, and CLI (`--block-private-network`, `--upload-dir`).
+
+See `barebrowse.context.md` and the PRD's "Security Model & Safe Defaults" for the full rationale.
+
 ## What the agent sees
 
 Raw ARIA output from a page is noisy -- decorative wrappers, hidden elements, structural junk. The pruning pipeline (ported from [mcprune](https://github.com/hamr0/mcprune)) strips it down to what matters.

--- a/barebrowse.context.md
+++ b/barebrowse.context.md
@@ -1,7 +1,7 @@
 # barebrowse -- Integration Guide
 
 > For AI assistants and developers wiring barebrowse into a project.
-> v0.9.1 | Node.js >= 22 | 0 required deps | Apache-2.0
+> v0.11.0 | Node.js >= 22 | 0 required deps | Apache-2.0
 
 ## What this is
 
@@ -95,6 +95,9 @@ const snapshot = await browse('https://example.com', {
 - `downloadPath: '/abs/dir'` — Where downloads land. Default: per-session `mkdtemp` under `/tmp/barebrowse-dl-*` that gets removed on `close()`. Caller-supplied paths are not cleaned up — caller owns the lifecycle.
 - `blockAds: true|false` — CDP-level URL blocking of 128 common ad/tracker patterns (Google ads/analytics, FB/Amazon/MS/Adobe ad+analytics, Segment/Amplitude/Mixpanel/Heap/PostHog, Hotjar/FullStory/LogRocket, Criteo/Taboola/Outbrain, the consumer-pixel cluster, AppNexus/Rubicon/PubMatic supply, marketing automation; v0.10.1 added AppsFlyer/Branch/Adjust, Cloudflare Web Analytics, Matomo Cloud). Default `true` for launched browsers, `false` in attach mode (would affect any tab in the user's running browser). Explicit `true` in attach mode is honored and follows the session across `switchTab()` (regression-tested). Shrinks ARIA snapshots and speeds page loads. On legacy Chromium lacking `Network.setBlockedURLs` a one-time `console.warn` surfaces the fallback.
 - `blockUrls: ['*://foo.com/*', ...]` — Extra glob patterns (CDP `Network.setBlockedURLs` format) to block in addition to the default. Merged with the default unless `blockAds: false`.
+- `allowLocalUrls: true|false` — (v0.11.0) Default `false`: navigation to local-resource / browser-internal schemes (`file:`, `view-source:`, `chrome:`, `filesystem:`, `devtools:`, …) is **blocked** to stop a prompt-injected agent reading local files. `http`/`https`/`data`/`blob`/`about` are always allowed. Set `true` to permit local schemes.
+- `blockPrivateNetwork: true|false` — (v0.11.0) Default `false`. When `true`, `goto()`/`browse()` refuse loopback / RFC-1918 / link-local / cloud-metadata (`169.254.169.254`) / `*.internal` hosts (SSRF guard). Off by default so localhost dev-server browsing works. Hostname-based — does not catch DNS names that resolve to private IPs.
+- `uploadDir: '/abs/dir'` — (v0.11.0) Default unset (no restriction). When set, `upload()` rejects any file that does not resolve (symlinks included, via `realpath`) inside this directory — sandboxes the agent's file-upload capability.
 
 ## Snapshot format
 
@@ -226,7 +229,7 @@ barebrowse save-state                  # → .barebrowse/state-<timestamp>.json
 barebrowse close                       # Kill daemon + browser
 ```
 
-**Open flags:** `--mode=headless|headed|hybrid`, `--port=N` (attach to running browser), `--proxy=URL`, `--viewport=WxH`, `--storage-state=FILE`, `--download-path=DIR` (v0.9.0), `--no-cookies`, `--browser=firefox|chromium`, `--timeout=N`
+**Open flags:** `--mode=headless|headed|hybrid`, `--port=N` (attach to running browser), `--proxy=URL`, `--viewport=WxH`, `--storage-state=FILE`, `--download-path=DIR` (v0.9.0), `--no-cookies`, `--browser=firefox|chromium`, `--timeout=N`, `--block-private-network` (SSRF guard, v0.11.0), `--upload-dir=DIR` (upload sandbox, v0.11.0)
 
 Session lifecycle: `open` spawns a background daemon holding a `connect()` session. Subsequent commands POST to the daemon over HTTP (localhost). `close` shuts everything down. JS dialogs (alert/confirm/prompt) are auto-dismissed and logged.
 
@@ -354,6 +357,10 @@ Useful for agent threshold decisions: "skip sites above score 40", "warn if term
 13. **Refs are globally flat across frames.** v0.9.0 (H2) assigns refs from a shared counter across the merged frame tree, so a `[ref=42]` from an iframe and a `[ref=43]` from the parent come from one address space. The visible `[ref=N]` format is unchanged. refMap stores `{session, backendNodeId}` so `click(ref)` automatically dispatches in the right frame's session.
 
 14. **`eval` MCP tool is opt-in.** Set `BAREBROWSE_MCP_EVAL=1` to register it. Default off because `Runtime.evaluate` in an authenticated session can read cookies/localStorage, post on the user's behalf, hit any same-origin endpoint. CLI/connect()/daemon all keep `eval` because the developer is the caller; MCP gates it because the agent acts with less judgment.
+
+15. **The CLI daemon requires a per-session token (v0.11.0).** `open` mints a 32-byte random token, writes it into `.barebrowse/session.json` (mode `0600`) and requires it on `POST /command` via the `x-barebrowse-token` header (loopback is shared across local users, so binding to `127.0.0.1` alone isn't an authorization boundary). The bundled `session-client` sends it automatically — no change for CLI users. A third-party client hitting the daemon HTTP API directly must read the token from `session.json` and send it. `GET /status` stays open (liveness only). The session dir is `0700`; snapshots, `saveState`, and logs are written `0600`.
+
+16. **Navigation is scheme-guarded by default (v0.11.0).** `file:`/`chrome:`/etc. throw unless `allowLocalUrls: true`; `blockPrivateNetwork` and `uploadDir` add opt-in SSRF and upload-sandbox controls. All four are exposed identically on the library, MCP/bareagent (via `connect` opts), and the CLI (`--block-private-network`, `--upload-dir=DIR`; the scheme guard and token are always on).
 
 ## Constraints
 

--- a/cli.js
+++ b/cli.js
@@ -119,6 +119,8 @@ async function cmdOpen() {
     downloadPath: parseFlag('--download-path'),
     blockAds: hasFlag('--no-block-ads') ? false : undefined,
     blockUrls: parseFlagAll('--block-urls'),
+    blockPrivateNetwork: hasFlag('--block-private-network') || undefined,
+    uploadDir: parseFlag('--upload-dir') ? resolve(parseFlag('--upload-dir')) : undefined,
   };
 
   try {
@@ -222,6 +224,8 @@ async function runDaemonInternal() {
     downloadPath: parseFlag('--download-path'),
     blockAds: hasFlag('--no-block-ads') ? false : undefined,
     blockUrls: parseFlagAll('--block-urls'),
+    blockPrivateNetwork: hasFlag('--block-private-network') || undefined,
+    uploadDir: parseFlag('--upload-dir'),
   };
   const outputDir = parseFlag('--output-dir') || resolve('.barebrowse');
   const url = parseFlag('--url');
@@ -489,6 +493,10 @@ Session:
                                     Default: enabled in owned-browser modes, disabled in attach mode.
     --block-urls=PATTERN            Extra URL glob to block (repeatable, e.g. --block-urls='*://*.foo.com/*').
                                     Use the =VALUE form when the pattern could be mistaken for a flag.
+    --block-private-network         SSRF guard: refuse to navigate to loopback / RFC-1918 / link-local /
+                                    cloud-metadata hosts. Off by default so localhost browsing works.
+    --upload-dir=DIR                Sandbox uploads: reject files outside DIR (symlinks resolved).
+                                    Default: no restriction. (file:/chrome: schemes are always blocked.)
 
 Navigation:
   barebrowse goto <url>             Navigate to URL

--- a/commands/barebrowse.md
+++ b/commands/barebrowse.md
@@ -38,6 +38,10 @@ All output files go to `.barebrowse/` in the current directory. Read them with t
 - `--proxy=URL` — HTTP/SOCKS proxy server
 - `--viewport=WxH` — Viewport size (e.g. 1280x720)
 - `--storage-state=FILE` — Load cookies/localStorage from JSON file
+- `--block-private-network` — SSRF guard: refuse loopback / RFC-1918 / link-local / cloud-metadata hosts (v0.11.0)
+- `--upload-dir=DIR` — Sandbox uploads to DIR; reject files outside it (v0.11.0)
+
+> Security (v0.11.0): `file:`/`chrome:`/etc. navigation is blocked by default, and the daemon requires a per-session token (handled transparently by the CLI). Snapshots and saved state are written owner-only (`0600`).
 
 ### Navigation
 

--- a/commands/barebrowse/SKILL.md
+++ b/commands/barebrowse/SKILL.md
@@ -39,6 +39,10 @@ All output files go to `.barebrowse/` in the current directory. Read them with t
 - `--proxy=URL` — HTTP/SOCKS proxy server
 - `--viewport=WxH` — Viewport size (e.g. 1280x720)
 - `--storage-state=FILE` — Load cookies/localStorage from JSON file
+- `--block-private-network` — SSRF guard: refuse loopback / RFC-1918 / link-local / cloud-metadata hosts (v0.11.0)
+- `--upload-dir=DIR` — Sandbox uploads to DIR; reject files outside it (v0.11.0)
+
+> Security (v0.11.0): `file:`/`chrome:`/etc. navigation is blocked by default, and the daemon requires a per-session token (handled transparently by the CLI). Snapshots and saved state are written owner-only (`0600`).
 
 ### Navigation
 

--- a/docs/00-context/system-state.md
+++ b/docs/00-context/system-state.md
@@ -82,6 +82,7 @@ Every action returns a **pruned ARIA snapshot** -- the agent's view of the page 
 | **Profile locking** | Unique temp dir per headless instance (`/tmp/barebrowse-<pid>-<ts>`) | Headless |
 | **Shared memory crash** (Linux) | `--disable-dev-shm-usage` prevents `/dev/shm` exhaustion under heavy tab load | Headless |
 | **ARIA noise** | 9-step pruning: wrapper collapse, noise removal, landmark promotion | Both |
+| **Hostile navigation (prompt-injected agent)** | v0.11.0: `goto()`/`browse()` block `file:`/`view-source:`/`chrome:`/etc. by default (`src/url-guard.js`); opt-in `blockPrivateNetwork` (loopback/RFC-1918/link-local/cloud-metadata SSRF guard) and `uploadDir` (realpath-checked upload sandbox). Cookie injection scoped by precise RFC-6265 domain match | Both |
 
 ### Not yet handled
 
@@ -331,6 +332,8 @@ barebrowse close                       # Kill daemon + browser
 ```
 
 Architecture: `open` spawns a detached child process running an HTTP server on a random localhost port. Session state stored in `.barebrowse/session.json`. Subsequent commands POST to the daemon. `close` sends shutdown, daemon calls `page.close()` + `process.exit(0)`.
+
+**Auth (v0.11.0):** loopback alone is not an authorization boundary (shared across local users), so the daemon mints a 32-byte token at startup, writes it into `session.json` (mode `0600`) and requires it on `POST /command` via `x-barebrowse-token` (constant-time compare). `session-client` sends it transparently. Session dir is `0700`; snapshots/`saveState`/logs are `0600`. `GET /status` stays open (liveness only).
 
 Full commands: open, close, status, goto, back, forward, snapshot, screenshot, pdf, click, type, fill, press, scroll, hover, select, drag, upload, tabs, tab, eval, wait-idle, wait-for, console-logs, network-log, dialog-log, save-state.
 

--- a/docs/01-product/prd.md
+++ b/docs/01-product/prd.md
@@ -1,8 +1,8 @@
 # barebrowse — Product Requirements Document
 
-**Version:** 1.2
-**Date:** 2026-05-18
-**Status:** Phase B (headed enhancements + bot-resistance + MCP completeness) complete @ v0.9.0; pruneMode follow-up shipped @ v0.9.1 — `read` alias wired in `prune.js` and `pruneMode: 'act'|'read'` exposed on the MCP / bareagent `browse` + `snapshot` tools, plus an auto-hint when act-mode collapses a content page. All H1–H9 shipped one commit each (see `docs/02-features/fix-plan.md`). No outstanding Phase B follow-ups.
+**Version:** 1.3
+**Date:** 2026-05-23
+**Status:** Phase B (headed enhancements + bot-resistance + MCP completeness) complete @ v0.9.0; pruneMode follow-up shipped @ v0.9.1. v0.10.x added ad/tracker blocking + canvas-noise stealth. **v0.11.0 = security hardening release** — full audit of library + CLI daemon + MCP server; eight findings fixed and regression-tested (157 passing). See the "Security model & safe defaults" section below and the v0.11.0 CHANGELOG entry.
 
 ---
 
@@ -112,6 +112,23 @@ After connection, every CDP command is the same. Three modes = ~20 extra lines i
 
 **Limitation:** Cookies expire. This works for existing sessions, not new logins. For sites requiring fresh auth, headed mode with user interaction is the fallback.
 
+### Security Model & Safe Defaults
+
+**Decision (v0.11.0):** barebrowse hands an autonomous — and therefore prompt-injectable — agent an *authenticated* browser. The threat model is (a) page-sourced instructions steering the agent into local/internal resources or file exfiltration, and (b) other local users/processes on a shared host. Defaults are calibrated to `severity × likelihood` vs. cost-of-breaking-legit-use, and a safe default never forces the user to disable a *different* safe default to get work done.
+
+| Control | Default | Rationale |
+|---|---|---|
+| **Navigation scheme guard** | **On.** `file:`/`view-source:`/`chrome:`/`filesystem:`/`devtools:`/… rejected; `http`/`https`/`data`/`blob`/`about` allowed | A *web*-browsing tool reaching the local filesystem is almost never intended and is a confirmed file-read / directory-listing vector. `data:` is opaque-origin (no `file://` or cross-origin read) and the test-fixture mechanism, so blocking it would buy nothing and only push users onto `allowLocalUrls` — which *also* re-opens `file://`. One uncoupled escape hatch: `allowLocalUrls: true`. |
+| **Private-network / SSRF guard** | **Opt-in** (`blockPrivateNetwork`) | Blocking loopback / RFC-1918 / link-local / cloud-metadata by default would break the common, legitimate case of pointing an agent at a local dev server. Security-conscious deployments enable it; metadata-credential and internal-recon vectors then close. |
+| **Upload sandbox** | **Opt-in** (`uploadDir`) | Uploading files is a stated feature (job applications, KYC, media); files legitimately come from anywhere. A default confinement would break that. When set, paths must resolve (symlinks included) inside the directory. |
+| **Daemon authentication** | **On.** Per-session 32-byte token, required on `/command` | The CLI daemon binds loopback, but loopback is shared across local users. Without a token any local process could drive the authenticated browser (incl. `eval`). Token lives in `session.json` (mode `0600`); the bundled client sends it transparently. |
+| **Artifact permissions** | **On.** session dir `0700`, sensitive files `0600` | Snapshots (authenticated content) and `saveState` output (cookies + localStorage = session tokens) must not be world-readable on a multi-user host. |
+| **MCP `eval`** | **Opt-in** (`BAREBROWSE_MCP_EVAL=1`) | `Runtime.evaluate` in an authenticated session is full access. The agent acts with less judgment than a developer, so the MCP surface gates it; CLI/connect/daemon keep it (developer is the caller) but the daemon now requires the auth token. |
+
+Cookie injection is scoped by a precise RFC-6265 domain match (not a substring `LIKE`), so browsing one site can't pull look-alike or unrelated-eTLD cookies into the session. Every safety control is expressed identically across the library, MCP, bareagent, and CLI surfaces — no entry point is a less-securable path.
+
+**Known limitation:** the private-network guard matches the URL hostname; a public DNS name that resolves to a private IP (DNS rebinding) is not caught — that needs connection-time IP inspection.
+
 ### Pruning (Absorbed from mcprune)
 
 **Decision:** Port mcprune's role-based ARIA tree pruning into barebrowse as a built-in step, not an optional module.
@@ -184,7 +201,13 @@ const tree = await browse('https://example.com', {
 });
 
 // Long-lived session for interaction
-const page = await connect({ mode: 'headed' });
+const page = await connect({
+  mode: 'headed',
+  // Safety controls (v0.11.0):
+  allowLocalUrls: false,       // default: file:/chrome:/etc. navigation is blocked
+  blockPrivateNetwork: false,  // opt-in SSRF guard (loopback/RFC-1918/metadata)
+  uploadDir: '/tmp/agent-uploads', // opt-in: confine upload() to this directory
+});
 await page.goto('https://amazon.com/cart');
 await page.click('[data-action="checkout"]');
 await page.type('#gift-message', 'Happy birthday!');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "barebrowse",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Authenticated web browsing for autonomous agents via CDP. URL in, pruned ARIA snapshot out.",
   "type": "module",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "headless"
   ],
   "optionalDependencies": {
-    "wearehere": "^1.0.0"
+    "wearehere": "1.0.0"
   },
   "license": "Apache-2.0"
 }

--- a/src/auth.js
+++ b/src/auth.js
@@ -269,6 +269,22 @@ export async function injectCookies(session, cookies) {
 }
 
 /**
+ * RFC 6265 domain-match: does `host` belong to a cookie declared for
+ * `cookieDomain`? Leading dot on the cookie domain is ignored (host-only
+ * vs domain cookies are matched the same here, intentionally — we want
+ * parent-domain cookies like .google.com to apply to mail.google.com).
+ * @param {string} host - target hostname (e.g. 'mail.google.com')
+ * @param {string} cookieDomain - cookie's host_key (e.g. '.google.com')
+ * @returns {boolean}
+ */
+export function cookieDomainMatch(host, cookieDomain) {
+  const h = String(host).toLowerCase();
+  const d = String(cookieDomain).toLowerCase().replace(/^\./, '');
+  if (!d) return false;
+  return h === d || h.endsWith('.' + d);
+}
+
+/**
  * Extract cookies for a URL and inject them into a CDP session.
  * Convenience function combining extractCookies + injectCookies.
  * @param {object} session - CDP session handle
@@ -276,12 +292,18 @@ export async function injectCookies(session, cookies) {
  * @param {object} [opts] - Options passed to extractCookies
  */
 export async function authenticate(session, url, opts = {}) {
-  // Strip to registrable domain so mail.google.com → google.com
-  // This ensures parent-domain cookies (.google.com) are included
-  const hostname = new URL(url).hostname.replace(/^www\./, '');
-  const parts = hostname.split('.');
-  const domain = parts.length > 2 ? parts.slice(-2).join('.') : hostname;
-  const cookies = extractCookies({ ...opts, domain });
+  const fullHost = new URL(url).hostname.toLowerCase();
+  // Coarse SQL pre-filter: strip to a registrable-ish domain so the LIKE query
+  // returns a superset (incl. parent-domain cookies). slice(-2) is a cheap
+  // heuristic — it over-selects for multi-part eTLDs (co.uk) and as a substring
+  // match, so the precise RFC-6265 domain-match below is what actually decides
+  // which cookies get injected. Without it, browsing apple.com would inject
+  // cookies for apple.com.evil.org and every *.co.uk site (verified).
+  const noWww = fullHost.replace(/^www\./, '');
+  const parts = noWww.split('.');
+  const coarseDomain = parts.length > 2 ? parts.slice(-2).join('.') : noWww;
+  const candidates = extractCookies({ ...opts, domain: coarseDomain });
+  const cookies = candidates.filter((c) => cookieDomainMatch(fullHost, c.domain));
   if (cookies.length > 0) {
     await injectCookies(session, cookies);
   }

--- a/src/chromium.js
+++ b/src/chromium.js
@@ -5,8 +5,13 @@
  * Modes: headless (launch new, no UI), headed (launch new, visible window).
  */
 
-import { execSync, spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { existsSync, rmSync } from 'node:fs';
+
+/** Block the current thread for `ms` without spawning a process. */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
 
 // Track launched browsers so we can clean them up if the parent crashes.
 // Registered exit handlers (one-time) iterate this set on shutdown.
@@ -29,7 +34,7 @@ function reapAllSync() {
   for (const b of toReap) {
     for (let i = 0; i < 20; i++) {
       try { process.kill(b.process.pid, 0); } catch { break; }
-      try { execSync('sleep 0.05'); } catch {}
+      sleepSync(50);
     }
     if (b.ownedProfileDir) {
       try { rmSync(b.ownedProfileDir, { recursive: true, force: true }); } catch {}
@@ -84,8 +89,11 @@ export function findBrowser() {
         if (existsSync(candidate)) return candidate;
         continue;
       }
-      // Relative name — check via which
-      const path = execSync(`which ${candidate} 2>/dev/null`, { encoding: 'utf8' }).trim();
+      // Relative name — resolve via `which` (execFile: no shell, no injection)
+      const path = execFileSync('which', [candidate], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
       if (path) return path;
     } catch {
       // Not found, try next

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -8,8 +8,24 @@
 import { createServer } from 'node:http';
 import { spawn } from 'node:child_process';
 import { writeFileSync, mkdirSync, existsSync, readFileSync, unlinkSync } from 'node:fs';
+import { randomBytes, timingSafeEqual } from 'node:crypto';
 import { join, resolve } from 'node:path';
 import { connect } from './index.js';
+
+/** Owner-only file write helper — daemon artifacts can hold authenticated content. */
+function writeFilePrivate(path, data) {
+  writeFileSync(path, data, { mode: 0o600 });
+}
+
+/** Constant-time token compare; false on any length/format mismatch. */
+function tokenMatches(expected, got) {
+  if (typeof got !== 'string' || got.length !== expected.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(got), Buffer.from(expected));
+  } catch {
+    return false;
+  }
+}
 
 const SESSION_FILE = 'session.json';
 
@@ -19,7 +35,7 @@ const SESSION_FILE = 'session.json';
  */
 export async function startDaemon(opts, outputDir, initialUrl) {
   const absDir = resolve(outputDir);
-  mkdirSync(absDir, { recursive: true });
+  mkdirSync(absDir, { recursive: true, mode: 0o700 });
 
   // Clean stale session
   const sessionPath = join(absDir, SESSION_FILE);
@@ -44,6 +60,8 @@ export async function startDaemon(opts, outputDir, initialUrl) {
   if (Array.isArray(opts.blockUrls)) {
     for (const p of opts.blockUrls) args.push('--block-urls', p);
   }
+  if (opts.blockPrivateNetwork) args.push('--block-private-network');
+  if (opts.uploadDir) args.push('--upload-dir', opts.uploadDir);
 
   const child = spawn(process.execPath, args, {
     detached: true,
@@ -75,7 +93,13 @@ export async function startDaemon(opts, outputDir, initialUrl) {
  */
 export async function runDaemon(opts, outputDir, initialUrl) {
   const absDir = resolve(outputDir);
-  mkdirSync(absDir, { recursive: true });
+  mkdirSync(absDir, { recursive: true, mode: 0o700 });
+
+  // Per-session auth token. The daemon binds to loopback, but loopback is
+  // shared across local users — without a token any local user/process could
+  // POST /command and drive the authenticated browser (incl. `eval`). The
+  // token is written into session.json (mode 0600) so only the owner reads it.
+  const authToken = randomBytes(32).toString('hex');
 
   // Connect to browser
   const page = await connect({
@@ -88,6 +112,8 @@ export async function runDaemon(opts, outputDir, initialUrl) {
     downloadPath: opts.downloadPath,
     blockAds: opts.blockAds,
     blockUrls: opts.blockUrls,
+    blockPrivateNetwork: opts.blockPrivateNetwork,
+    uploadDir: opts.uploadDir,
   });
 
   // Console log capture
@@ -161,7 +187,7 @@ export async function runDaemon(opts, outputDir, initialUrl) {
       const text = await page.snapshot({ mode: pruneMode });
       const ts = new Date().toISOString().replace(/[:.]/g, '-');
       const file = join(absDir, `page-${ts}.yml`);
-      writeFileSync(file, text);
+      writeFilePrivate(file, text);
       return { ok: true, file };
     },
 
@@ -170,7 +196,7 @@ export async function runDaemon(opts, outputDir, initialUrl) {
       const ts = new Date().toISOString().replace(/[:.]/g, '-');
       const ext = format || 'png';
       const file = join(absDir, `screenshot-${ts}.${ext}`);
-      writeFileSync(file, Buffer.from(data, 'base64'));
+      writeFilePrivate(file, Buffer.from(data, 'base64'));
       return { ok: true, file };
     },
 
@@ -244,7 +270,7 @@ export async function runDaemon(opts, outputDir, initialUrl) {
       const data = await page.pdf({ landscape });
       const ts = new Date().toISOString().replace(/[:.]/g, '-');
       const file = join(absDir, `page-${ts}.pdf`);
-      writeFileSync(file, Buffer.from(data, 'base64'));
+      writeFilePrivate(file, Buffer.from(data, 'base64'));
       return { ok: true, file };
     },
 
@@ -273,7 +299,7 @@ export async function runDaemon(opts, outputDir, initialUrl) {
     async 'dialog-log'() {
       const ts = new Date().toISOString().replace(/[:.]/g, '-');
       const file = join(absDir, `dialogs-${ts}.json`);
-      writeFileSync(file, JSON.stringify(page.dialogLog, null, 2));
+      writeFilePrivate(file, JSON.stringify(page.dialogLog, null, 2));
       return { ok: true, file, count: page.dialogLog.length };
     },
 
@@ -304,7 +330,7 @@ export async function runDaemon(opts, outputDir, initialUrl) {
       if (level) logs = logs.filter((l) => l.type === level);
       const ts = new Date().toISOString().replace(/[:.]/g, '-');
       const file = join(absDir, `console-${ts}.json`);
-      writeFileSync(file, JSON.stringify(logs, null, 2));
+      writeFilePrivate(file, JSON.stringify(logs, null, 2));
       if (clear) consoleLogs.length = 0;
       return { ok: true, file, count: logs.length };
     },
@@ -314,7 +340,7 @@ export async function runDaemon(opts, outputDir, initialUrl) {
       if (failed) logs = logs.filter((l) => l.status === 0 || l.status >= 400);
       const ts = new Date().toISOString().replace(/[:.]/g, '-');
       const file = join(absDir, `network-${ts}.json`);
-      writeFileSync(file, JSON.stringify(logs, null, 2));
+      writeFilePrivate(file, JSON.stringify(logs, null, 2));
       return { ok: true, file, count: logs.length };
     },
 
@@ -343,6 +369,14 @@ export async function runDaemon(opts, outputDir, initialUrl) {
     if (req.method !== 'POST' || req.url !== '/command') {
       res.writeHead(404);
       res.end('Not found');
+      return;
+    }
+
+    // Require the per-session token. Rejects any local process that hasn't
+    // read session.json (which is owner-only). Constant-time compare.
+    if (!tokenMatches(authToken, req.headers['x-barebrowse-token'])) {
+      res.writeHead(401, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: false, error: 'Unauthorized: missing or invalid token' }));
       return;
     }
 
@@ -388,11 +422,13 @@ export async function runDaemon(opts, outputDir, initialUrl) {
 
   const port = server.address().port;
 
-  // Write session.json so parent/clients can find us
+  // Write session.json so parent/clients can find us. Owner-only: it carries
+  // the auth token that gates /command.
   const sessionPath = join(absDir, SESSION_FILE);
-  writeFileSync(sessionPath, JSON.stringify({
+  writeFilePrivate(sessionPath, JSON.stringify({
     port,
     pid: process.pid,
+    token: authToken,
     startedAt: new Date().toISOString(),
   }));
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,9 @@ import { dismissConsent } from './consent.js';
 import { applyStealth } from './stealth.js';
 import { DEFAULT_BLOCKLIST } from './blocklist.js';
 import { waitForNetworkIdle } from './network-idle.js';
+import { assertNavigable, assertUploadAllowed } from './url-guard.js';
 import { join as pathJoin } from 'node:path';
+import { chmodSync } from 'node:fs';
 
 /**
  * Browse a URL and return an ARIA snapshot.
@@ -40,6 +42,10 @@ import { join as pathJoin } from 'node:path';
 export async function browse(url, opts = {}) {
   const mode = opts.mode || 'headless';
   const timeout = opts.timeout || 30000;
+
+  // Reject local-resource schemes (and optionally private hosts) before we
+  // spend a browser launch on a URL we won't navigate to.
+  assertNavigable(url, { allowLocalUrls: opts.allowLocalUrls, blockPrivateNetwork: opts.blockPrivateNetwork });
 
   let browser = null;
   let cdp = null;
@@ -154,6 +160,15 @@ export async function browse(url, opts = {}) {
  *   attached to and follows the session across switchTab() until close.
  * @param {string[]} [opts.blockUrls] - Extra URL glob patterns to block,
  *   merged with the default unless blockAds is false.
+ * @param {boolean} [opts.allowLocalUrls=false] - Permit navigation to local-
+ *   resource schemes (file:, view-source:, chrome:, …). Blocked by default
+ *   because a prompt-injected agent could use them to read local files.
+ * @param {boolean} [opts.blockPrivateNetwork=false] - Reject navigation to
+ *   loopback / RFC-1918 / link-local / cloud-metadata hosts (SSRF guard).
+ *   Off by default so localhost dev-server browsing keeps working.
+ * @param {string} [opts.uploadDir] - When set, upload() rejects any file that
+ *   does not resolve (symlinks included) inside this directory. Sandboxes the
+ *   agent's file-upload capability. Default: no restriction.
  * @returns {Promise<object>} Page handle with goto, snapshot, close
  */
 export async function connect(opts = {}) {
@@ -164,6 +179,11 @@ export async function connect(opts = {}) {
   // Forward caller-supplied launch knobs into every launch() below,
   // including hybrid-fallback re-launches inside goto().
   const launchOpts = { proxy: opts.proxy, binary: opts.binary, userDataDir: opts.userDataDir };
+  // Navigation safety policy, applied on every goto()/createTab().goto().
+  const urlGuard = { allowLocalUrls: opts.allowLocalUrls, blockPrivateNetwork: opts.blockPrivateNetwork };
+  // Optional upload sandbox: when set, upload() rejects files outside this dir.
+  // assertUploadAllowed resolves it (realpath) at check time.
+  const uploadDir = opts.uploadDir || null;
 
   if (attachMode) {
     // Reuse the user's running browser — do not launch, do not own the
@@ -312,6 +332,7 @@ export async function connect(opts = {}) {
 
   return {
     async goto(url, timeout = 30000) {
+      assertNavigable(url, urlGuard);
       // Refs from the previous page are about to become invalid — clear
       // before navigating so a stale click(ref) errors clearly instead of
       // silently resolving to whatever backendNodeId happens to still be in
@@ -467,6 +488,10 @@ export async function connect(opts = {}) {
     async upload(ref, files) {
       const entry = refMap.get(ref);
       if (!entry) throw new Error(`No element found for ref "${ref}"`);
+      // Upload sandbox: when uploadDir is set, every path must resolve
+      // (symlinks included, via realpath) inside it. Stops a prompt-injected
+      // agent from attaching ~/.ssh/id_rsa or other arbitrary local files.
+      assertUploadAllowed(files, uploadDir);
       await cdpUpload(entry.session, entry.backendNodeId, files);
     },
 
@@ -535,7 +560,10 @@ export async function connect(opts = {}) {
       });
       const state = { cookies, localStorage: JSON.parse(result.value || '{}') };
       const { writeFileSync } = await import('node:fs');
-      writeFileSync(filePath, JSON.stringify(state, null, 2));
+      // State holds cookies + localStorage (session tokens) — write owner-only
+      // so a multi-user host can't read another user's credentials off disk.
+      writeFileSync(filePath, JSON.stringify(state, null, 2), { mode: 0o600 });
+      try { chmodSync(filePath, 0o600); } catch { /* best effort if pre-existing */ }
     },
 
     get botBlocked() { return botBlocked; },
@@ -590,6 +618,7 @@ export async function connect(opts = {}) {
       let tabBotBlocked = false;
       return {
         async goto(url, timeout = 30000) {
+          assertNavigable(url, urlGuard);
           await navigate(tab, url, timeout);
           if (opts.consent !== false) {
             await dismissConsent(tab.session);

--- a/src/session-client.js
+++ b/src/session-client.js
@@ -53,7 +53,11 @@ export async function sendCommand(command, args, outputDir) {
   try {
     res = await fetch(`http://127.0.0.1:${session.port}/command`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        // Authenticate to the daemon with the per-session token from session.json.
+        ...(session.token ? { 'x-barebrowse-token': session.token } : {}),
+      },
       body: JSON.stringify({ command, args }),
       signal: AbortSignal.timeout(60000),
     });

--- a/src/url-guard.js
+++ b/src/url-guard.js
@@ -1,0 +1,138 @@
+/**
+ * url-guard.js — Navigation safety checks for goto()/browse().
+ *
+ * Closes two confirmed vectors for an autonomous (and therefore
+ * prompt-injectable) agent:
+ *   1. Local-resource schemes (file:, view-source:, chrome:, …) that let a
+ *      page-sourced instruction read local files or browser internals.
+ *   2. Optional private-network blocking (loopback, RFC-1918, link-local,
+ *      cloud-metadata) to stop SSRF to internal services.
+ *
+ * Scheme blocking is on by default; private-network blocking is opt-in
+ * (blockPrivateNetwork) so localhost dev-server browsing keeps working.
+ *
+ * Limitation: private-network checks match the URL hostname only. A public
+ * DNS name that resolves to a private IP (DNS rebinding) is NOT caught here —
+ * that needs connection-time IP inspection. Documented, not silently assumed.
+ */
+
+import { realpathSync } from 'node:fs';
+import { resolve, sep } from 'node:path';
+
+// Schemes safe to navigate to. Everything else is treated as a local-resource
+// or browser-internal scheme and blocked unless allowLocalUrls is set.
+// data:/blob:/about: stay allowed: opaque origins, no file:// or cross-origin
+// read, and data: is the library's test-fixture mechanism.
+const ALLOWED_SCHEMES = new Set(['http:', 'https:', 'data:', 'blob:', 'about:']);
+
+/**
+ * @param {string} host - hostname (no brackets for IPv6)
+ * @returns {boolean} true if it names a private/loopback/link-local/internal host
+ */
+function isPrivateHost(host) {
+  const h = host.toLowerCase().replace(/^\[|\]$/g, ''); // strip IPv6 brackets
+
+  // Internal hostnames
+  if (h === 'localhost' || h.endsWith('.localhost')) return true;
+  if (h.endsWith('.local') || h.endsWith('.internal')) return true;
+  if (h === 'metadata.google.internal') return true;
+
+  // IPv4 (incl. ranges)
+  const v4 = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (v4) {
+    const [a, b] = [Number(v4[1]), Number(v4[2])];
+    if (a === 127) return true;                 // loopback 127.0.0.0/8
+    if (a === 10) return true;                   // 10.0.0.0/8
+    if (a === 0) return true;                    // 0.0.0.0/8
+    if (a === 169 && b === 254) return true;     // link-local / cloud metadata
+    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+    if (a === 192 && b === 168) return true;     // 192.168.0.0/16
+    return false;
+  }
+
+  // IPv6 — gated on the host actually being an IPv6 literal (contains a
+  // colon). Without this gate, ordinary hostnames like "fcbarcelona.com" or
+  // "fdic.gov" would match the fc00::/7 ULA prefix check and be wrongly blocked.
+  if (h.includes(':')) {
+    if (h === '::1' || h === '::') return true;        // loopback / unspecified
+    if (h.startsWith('fe80:')) return true;            // link-local fe80::/10
+    if (h.startsWith('fc') || h.startsWith('fd')) return true; // fc00::/7 ULA
+    // IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1)
+    const mapped = h.match(/::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+    if (mapped) return isPrivateHost(mapped[1]);
+    return false;
+  }
+
+  return false;
+}
+
+/**
+ * Throw if `url` is unsafe to navigate to under the given policy.
+ * @param {string} url
+ * @param {object} [opts]
+ * @param {boolean} [opts.allowLocalUrls=false] - permit file:/chrome:/etc.
+ * @param {boolean} [opts.blockPrivateNetwork=false] - reject loopback/RFC-1918/metadata.
+ */
+export function assertNavigable(url, opts = {}) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Refusing to navigate: not a valid URL (${String(url).slice(0, 80)})`);
+  }
+
+  if (!opts.allowLocalUrls && !ALLOWED_SCHEMES.has(parsed.protocol)) {
+    throw new Error(
+      `Refusing to navigate to "${parsed.protocol}" URL — local-resource and ` +
+      `browser-internal schemes are blocked (reads local files / browser state). ` +
+      `Pass { allowLocalUrls: true } to override.`
+    );
+  }
+
+  if (
+    opts.blockPrivateNetwork &&
+    (parsed.protocol === 'http:' || parsed.protocol === 'https:') &&
+    parsed.hostname &&
+    isPrivateHost(parsed.hostname)
+  ) {
+    throw new Error(
+      `Refusing to navigate to private/internal host "${parsed.hostname}" — ` +
+      `blockPrivateNetwork is enabled (SSRF guard). ` +
+      `Unset it to allow localhost / internal browsing.`
+    );
+  }
+}
+
+/**
+ * Throw if any file in `files` resolves outside `uploadDir`. Both the base
+ * dir and each file are resolved through realpath, so symlinks (in either the
+ * base path — e.g. macOS /tmp → /private/tmp — or the file) can't be used to
+ * escape the sandbox or to false-reject a legitimate file.
+ * No-op when `uploadDir` is falsy (no restriction configured).
+ * @param {string|string[]} files
+ * @param {string|null} uploadDir
+ */
+export function assertUploadAllowed(files, uploadDir) {
+  if (!uploadDir) return;
+  let baseReal;
+  try {
+    baseReal = realpathSync(resolve(uploadDir));
+  } catch {
+    throw new Error(`upload: uploadDir does not exist or is unreadable (${uploadDir})`);
+  }
+  const list = Array.isArray(files) ? files : [files];
+  for (const f of list) {
+    let real;
+    try {
+      real = realpathSync(resolve(String(f)));
+    } catch {
+      throw new Error(`upload: cannot resolve "${f}" (must exist inside uploadDir)`);
+    }
+    if (real !== baseReal && !real.startsWith(baseReal + sep)) {
+      throw new Error(`upload: "${f}" is outside the allowed uploadDir (${uploadDir})`);
+    }
+  }
+}
+
+// Exported for unit tests.
+export { isPrivateHost };

--- a/test/integration/cli.test.js
+++ b/test/integration/cli.test.js
@@ -52,6 +52,34 @@ describe('CLI session', () => {
     assert.ok(out.includes('Session running'), `expected running, got: ${out}`);
   });
 
+  it('session.json carries an auth token and is owner-readable only', async () => {
+    const { statSync } = await import('node:fs');
+    const session = JSON.parse(readFileSync(join(sessionDir, 'session.json'), 'utf8'));
+    assert.equal(typeof session.token, 'string', 'session should have a token');
+    assert.equal(session.token.length, 64, 'token should be 32 random bytes hex');
+    const mode = statSync(join(sessionDir, 'session.json')).mode & 0o777;
+    assert.equal(mode, 0o600, `session.json should be 0600, got ${mode.toString(8)}`);
+  });
+
+  it('daemon rejects /command without the token (no unauthenticated eval)', async () => {
+    const session = JSON.parse(readFileSync(join(sessionDir, 'session.json'), 'utf8'));
+    // No token header — any other local process would be in this position.
+    const res = await fetch(`http://127.0.0.1:${session.port}/command`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command: 'eval', args: { expression: '1336+1' } }),
+    });
+    assert.equal(res.status, 401, 'unauthenticated command must be rejected');
+    assert.equal((await res.json()).ok, false);
+    // Wrong token is also rejected.
+    const res2 = await fetch(`http://127.0.0.1:${session.port}/command`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-barebrowse-token': 'badtoken' },
+      body: JSON.stringify({ command: 'status', args: {} }),
+    });
+    assert.equal(res2.status, 401, 'wrong token must be rejected');
+  });
+
   it('snapshot creates a .yml file', () => {
     const out = cli(['snapshot'], { cwd: tmpDir });
     assert.ok(out.endsWith('.yml'), `expected .yml path, got: ${out}`);

--- a/test/unit/auth.test.js
+++ b/test/unit/auth.test.js
@@ -7,7 +7,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { extractCookies } from '../../src/auth.js';
+import { extractCookies, cookieDomainMatch } from '../../src/auth.js';
 
 describe('extractCookies()', () => {
   it('auto-detects a browser and returns cookies', () => {
@@ -62,5 +62,25 @@ describe('extractCookies()', () => {
     for (const cookie of cookies) {
       assert.ok(valid.has(cookie.sameSite), `${cookie.sameSite} should be valid sameSite`);
     }
+  });
+});
+
+describe('cookieDomainMatch() — precise injection filter', () => {
+  it('matches the host and its parent domains', () => {
+    assert.equal(cookieDomainMatch('mail.google.com', '.google.com'), true);
+    assert.equal(cookieDomainMatch('mail.google.com', 'google.com'), true);
+    assert.equal(cookieDomainMatch('www.example.com', 'www.example.com'), true);
+  });
+
+  it('rejects look-alike and unrelated domains (the over-match the LIKE pre-filter lets through)', () => {
+    assert.equal(cookieDomainMatch('apple.com', 'apple.com.evil.org'), false);
+    assert.equal(cookieDomainMatch('apple.com', 'notapple.com'), false);
+    // multi-part eTLD: browsing one .co.uk site must not pull another's cookies
+    assert.equal(cookieDomainMatch('mybank.co.uk', 'evil.co.uk'), false);
+    assert.equal(cookieDomainMatch('x.com', 'y.com'), false);
+  });
+
+  it('is case-insensitive', () => {
+    assert.equal(cookieDomainMatch('Mail.Google.COM', '.GOOGLE.com'), true);
   });
 });

--- a/test/unit/url-guard.test.js
+++ b/test/unit/url-guard.test.js
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for navigation safety (src/url-guard.js).
+ * Run: node --test test/unit/url-guard.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, mkdirSync, symlinkSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { assertNavigable, isPrivateHost, assertUploadAllowed } from '../../src/url-guard.js';
+
+describe('assertNavigable() — scheme policy', () => {
+  it('allows http/https/data/blob/about by default', () => {
+    for (const u of [
+      'http://example.com',
+      'https://example.com/path?q=1',
+      'data:text/html,<h1>x</h1>',
+      'about:blank',
+    ]) {
+      assert.doesNotThrow(() => assertNavigable(u), `${u} should be allowed`);
+    }
+  });
+
+  it('blocks local-resource and browser-internal schemes by default', () => {
+    for (const u of [
+      'file:///etc/passwd',
+      'file:///tmp/',
+      'view-source:https://example.com',
+      'chrome://settings',
+      'chrome-extension://abc/page.html',
+      'filesystem:https://x/temporary/f',
+      'devtools://devtools/bundled/x.html',
+    ]) {
+      assert.throws(() => assertNavigable(u), /Refusing to navigate/, `${u} should be blocked`);
+    }
+  });
+
+  it('honors allowLocalUrls to bypass the scheme block', () => {
+    assert.doesNotThrow(() => assertNavigable('file:///etc/hostname', { allowLocalUrls: true }));
+  });
+
+  it('rejects malformed URLs', () => {
+    assert.throws(() => assertNavigable('not a url'), /not a valid URL/);
+    assert.throws(() => assertNavigable(''), /not a valid URL/);
+  });
+});
+
+describe('assertNavigable() — private network policy', () => {
+  it('allows private hosts by default (localhost dev browsing)', () => {
+    for (const u of ['http://localhost:3000', 'http://127.0.0.1:8080', 'http://192.168.1.10']) {
+      assert.doesNotThrow(() => assertNavigable(u), `${u} should be allowed by default`);
+    }
+  });
+
+  it('blocks private/internal hosts when blockPrivateNetwork is set', () => {
+    for (const u of [
+      'http://localhost:3000',
+      'http://127.0.0.1/',
+      'http://169.254.169.254/latest/meta-data/',
+      'http://10.0.0.5/',
+      'http://192.168.0.1/',
+      'http://172.16.5.5/',
+      'http://metadata.google.internal/',
+      'https://something.internal/',
+    ]) {
+      assert.throws(() => assertNavigable(u, { blockPrivateNetwork: true }), /private\/internal/, `${u} should be blocked`);
+    }
+  });
+
+  it('still allows public hosts when blockPrivateNetwork is set', () => {
+    assert.doesNotThrow(() => assertNavigable('https://example.com', { blockPrivateNetwork: true }));
+    assert.doesNotThrow(() => assertNavigable('https://8.8.8.8', { blockPrivateNetwork: true }));
+  });
+});
+
+describe('isPrivateHost()', () => {
+  it('classifies IPv4 ranges', () => {
+    for (const h of ['127.0.0.1', '10.1.2.3', '192.168.0.1', '172.31.255.255', '169.254.169.254', '0.0.0.0']) {
+      assert.equal(isPrivateHost(h), true, `${h} should be private`);
+    }
+    for (const h of ['8.8.8.8', '1.1.1.1', '172.32.0.1', '93.184.216.34']) {
+      assert.equal(isPrivateHost(h), false, `${h} should be public`);
+    }
+  });
+
+  it('classifies IPv6 loopback / link-local / ULA', () => {
+    assert.equal(isPrivateHost('::1'), true);
+    assert.equal(isPrivateHost('[::1]'), true);
+    assert.equal(isPrivateHost('fe80::1'), true);
+    assert.equal(isPrivateHost('fd00::1'), true);
+    assert.equal(isPrivateHost('fc00::1'), true);
+    assert.equal(isPrivateHost('::ffff:127.0.0.1'), true);
+    assert.equal(isPrivateHost('2606:4700:4700::1111'), false);
+  });
+
+  it('does NOT misclassify hostnames that merely start with fc/fd as IPv6 ULA', () => {
+    // Regression: the fc00::/7 prefix check must be gated on the host being an
+    // IPv6 literal, or "fcbarcelona.com" / "fdic.gov" get wrongly blocked.
+    for (const h of ['fcbarcelona.com', 'fdic.gov', 'fd-domain.net', 'fconline.example']) {
+      assert.equal(isPrivateHost(h), false, `${h} is a public hostname`);
+    }
+    assert.doesNotThrow(() => assertNavigable('https://fcbarcelona.com', { blockPrivateNetwork: true }));
+    assert.doesNotThrow(() => assertNavigable('https://fdic.gov', { blockPrivateNetwork: true }));
+  });
+});
+
+describe('assertUploadAllowed()', () => {
+  it('is a no-op when no uploadDir is configured', () => {
+    assert.doesNotThrow(() => assertUploadAllowed(['/anything/at/all'], null));
+    assert.doesNotThrow(() => assertUploadAllowed(['/anything'], undefined));
+  });
+
+  it('allows files inside the dir and rejects files outside it', () => {
+    const base = mkdtempSync(join(tmpdir(), 'bb-upload-'));
+    try {
+      const inside = join(base, 'cv.pdf');
+      writeFileSync(inside, 'x');
+      const outside = mkdtempSync(join(tmpdir(), 'bb-other-'));
+      const secret = join(outside, 'secret');
+      writeFileSync(secret, 'x');
+      try {
+        assert.doesNotThrow(() => assertUploadAllowed([inside], base));
+        assert.throws(() => assertUploadAllowed([secret], base), /outside the allowed uploadDir/);
+        // accepts a single (non-array) path too
+        assert.doesNotThrow(() => assertUploadAllowed(inside, base));
+      } finally {
+        rmSync(outside, { recursive: true, force: true });
+      }
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves symlinks in the base dir (no false reject when uploadDir is a symlink)', () => {
+    // Mirrors macOS /tmp -> /private/tmp: base path has a symlinked component.
+    const real = mkdtempSync(join(tmpdir(), 'bb-real-'));
+    const link = real + '-link';
+    symlinkSync(real, link);
+    try {
+      const f = join(real, 'doc.txt');
+      writeFileSync(f, 'x');
+      // uploadDir given as the symlink; file given via the real path.
+      assert.doesNotThrow(() => assertUploadAllowed([f], link));
+      // and via the symlink path
+      assert.doesNotThrow(() => assertUploadAllowed([join(link, 'doc.txt')], link));
+    } finally {
+      rmSync(link, { force: true });
+      rmSync(real, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a missing file and a missing uploadDir', () => {
+    const base = mkdtempSync(join(tmpdir(), 'bb-upload-'));
+    try {
+      assert.throws(() => assertUploadAllowed([join(base, 'nope')], base), /cannot resolve/);
+      assert.throws(() => assertUploadAllowed(['/x'], join(base, 'does-not-exist')), /uploadDir does not exist/);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Full security audit of the barebrowse library + CLI daemon + MCP server. **8 findings + 2 review-found bugs**, each reproduced with a live PoC, fixed, and locked in with regression tests (**143 → 162 passing**). Bumps to **v0.11.0**.

Defaults are safe out of the box — the scheme guard and daemon token are always on; the disruptive controls (private-network block, upload sandbox) are opt-in on every surface (library / MCP / bareagent / CLI).

## Findings fixed

| Sev | Finding | Fix |
|-----|---------|-----|
| High | Daemon `eval` reachable unauthenticated over shared loopback | Per-session 32-byte token required on `/command` (constant-time compare); `session.json` `0600`, dir `0700` |
| Med | World-readable artifacts (snapshots, `saveState` = session tokens) | Written `0600`, session dir `0700` |
| Med | SSRF + `file://` read/dir-listing via `goto()` | Block `file:`/`view-source:`/`chrome:`/etc. by default (`src/url-guard.js`); opt-in `blockPrivateNetwork` |
| Med | Arbitrary file upload (exfil under prompt injection) | Opt-in `uploadDir` sandbox (realpath-checked) |
| Low | Over-broad cookie domain match (`apple.com` → `apple.com.evil.org`) | Precise RFC-6265 `cookieDomainMatch()` |
| Low | `which ${candidate}` shell footgun; `sleep` subprocess | `execFileSync` (no shell); `Atomics.wait` |
| Low | No `.gitignore`; `wearehere` floating `^1.0.0` | Added `.gitignore`; pinned `1.0.0` |

## Review-found bugs (also fixed + stress-tested)

- `isPrivateHost` wrongly classified any `fc*`/`fd*` **hostname** (e.g. `fcbarcelona.com`, `fdic.gov`) as IPv6 ULA — IPv6 checks now gated on the host being an IPv6 literal.
- Upload sandbox false-rejected valid files when `uploadDir` had a symlinked path component (macOS `/tmp`) — base dir now `realpath`'d too.

## Behavior changes (breaking)

1. `file:`/`chrome:`/etc. navigation now throws by default — pass `allowLocalUrls: true` to restore.
2. The CLI daemon now requires the token; transparent via the bundled `session-client`, but any third-party client hitting the daemon HTTP API directly must send `x-barebrowse-token` from `session.json`.

## Tests

`npm test` → **162/162 pass**. New: `test/unit/url-guard.test.js` (scheme/private-host/upload-sandbox), `cookieDomainMatch` cases, daemon token + perms in `test/integration/cli.test.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)