### PR TITLE
release: v0.15.0 — Firefox/BiDi engine + incognito clean session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## [0.15.0] - 2026-07-10
+
+### Added
+
+- **Firefox support via WebDriver BiDi (`connect({ engine: 'firefox' })`).** CDP
+  is deprecated in Firefox, so Firefox is driven over the W3C-standard BiDi
+  protocol — a second transport (`src/bidi.js`) over the *same* `ws` dependency,
+  with no geckodriver and no new package. Selectable from the CLI
+  (`barebrowse open <url> --engine firefox`) and MCP (`BAREBROWSE_ENGINE=firefox`).
+  - New modules: `bidi.js` (BiDi JSON-RPC transport), `firefox.js` (launch/find/
+    reap), `ax-snapshot.js` (reconstructs a CDP-vocabulary ARIA tree in-page —
+    BiDi has no `getFullAXTree` — with implicit roles, accessible-name
+    computation, `aria-hidden`/visibility filtering, and shadow-DOM/`<slot>`
+    traversal), `firefox-page.js` (the BiDi-backed page object).
+  - `prune.js`, `aria.js`, and `readable.js` are reused unchanged across engines
+    (readable.js refactored to share `EXTRACT_EXPRESSION` + `finalizeReadable`).
+  - Covers `goto`, `snapshot`, `click`, `type`, `press`, `scroll`, `hover`,
+    `select`, `drag`, `upload`, `goBack`/`goForward`, `reload`, `screenshot`,
+    `pdf`, `tabs`/`switchTab`, `waitFor`, `readable`, `injectCookies`, `close`.
+    The navigation guard and upload sandbox are enforced on the Firefox path for
+    parity with CDP.
+  - Fidelity validated against real CDP snapshots; iframes (incl. nested +
+    multi-tab), shadow DOM, CSP, and SPA timing covered in
+    `test/integration/firefox.test.js` (15 tests).
+
+- **Incognito mode — a clean, unauthenticated session (`incognito: true`).**
+  Skips ALL auth injection: no cookie extraction/injection and no
+  `storageState` loading, so the agent browses logged-out even though the
+  default throwaway profile is unchanged. The gate lives at the page-object
+  level, so it holds even when a caller (MCP `goto`, the daemon) injects
+  unconditionally. Available on `browse()`, `connect()`, both engines, MCP
+  (`browse` tool arg + `BAREBROWSE_INCOGNITO=1`), and CLI (`--incognito`).
+  Cookie injection is scoped to the target host on **both** engines via a
+  shared `scopedCookiesForUrl` (the Firefox path no longer loads the whole
+  cookie jar).
+
+### Known gaps (Firefox engine)
+
+- Consent auto-dismiss, stealth patches, and `hybrid` mode remain Chromium-only.
+- `reload()` cannot honour `ignoreCache` (Firefox BiDi does not support it yet).
+- The CLI daemon's console/network log capture is CDP-only, so those logs are
+  empty for a Firefox session. `saveState`, `waitForNavigation`, and
+  `waitForNetworkIdle` are CDP-only too — on Firefox they throw a clear
+  "not supported on the Firefox/BiDi engine" error, and download/dialog logs
+  read empty. Accessible-name computation is a high-value subset of the full
+  W3C accname spec.
+
 ## [0.14.0] - 2026-06-15
 
 ### Documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,3 +22,7 @@
 - **Docs:** `docs/README.md` (navigation guide to all documentation)
 
 For full development and testing standards, see `.claude/memory/AGENT_RULES.md`.
+
+<!-- MEMORY:START -->
+@.claude/remember/MEMORY.md
+<!-- MEMORY:END -->

--- a/README.md
+++ b/README.md
@@ -132,6 +132,21 @@ const snap = await page.snapshot();
 await page.close(); // closes only the tab barebrowse opened — your browser keeps running
 ```
 
+### Firefox (WebDriver BiDi)
+
+CDP is deprecated in Firefox, so barebrowse drives it over the W3C WebDriver
+BiDi protocol instead — a second transport over the same `ws` dependency, no
+extra download. Same `page.*` API (the ARIA snapshot is reconstructed in-page
+since BiDi has no `getFullAXTree`):
+
+```js
+const page = await connect({ engine: 'firefox' }); // headless by default
+```
+
+From the CLI: `barebrowse open <url> --engine firefox`. From MCP: set
+`BAREBROWSE_ENGINE=firefox`. Firefox cookies (plaintext) reuse into the same
+engine. Chromium (CDP) remains the default; `hybrid` mode is Chromium-only.
+
 No clone profile, no fresh cookies — the agent sees what you see.
 
 ## What it handles automatically
@@ -223,7 +238,7 @@ URL -> find/launch browser (chromium.js)
 ## Requirements
 
 - Node.js >= 22 (built-in WebSocket, built-in SQLite)
-- Any Chromium-based browser installed (Chrome, Chromium, Brave, Edge, Vivaldi)
+- Any Chromium-based browser installed (Chrome, Chromium, Brave, Edge, Vivaldi) — or Firefox (>= 121) for the `engine: 'firefox'` BiDi path
 - Linux tested (Fedora/KDE). macOS/Windows cookie paths exist but untested.
 
 ## The bare ecosystem

--- a/barebrowse.context.md
+++ b/barebrowse.context.md
@@ -46,6 +46,7 @@ const snapshot = await browse('https://example.com');
 const snapshot = await browse('https://example.com', {
   mode: 'headless',      // 'headless' | 'headed' | 'hybrid'
   cookies: true,         // inject user's browser cookies
+  incognito: false,      // clean, unauthenticated session: skip ALL auth injection
   browser: 'firefox',    // cookie source: 'firefox' | 'chromium' (auto-detected)
   prune: true,           // apply ARIA pruning (47-95% token reduction)
   pruneMode: 'act',      // 'act' (interactive elements) | 'read' (all content)
@@ -94,10 +95,12 @@ const snapshot = await browse('https://example.com', {
 | `close()` | -- | void | Close page, disconnect CDP, kill browser (if headless) |
 
 **connect() options** (in addition to mode/port/consent):
+- `engine: 'chromium'|'firefox'` — Browser engine. Default `chromium` (CDP). `firefox` drives Firefox over WebDriver BiDi (CDP is deprecated there) — a separate transport with the same `page.*` API; the ARIA snapshot is reconstructed in-page since BiDi has no `getFullAXTree`. Chromium-only: `hybrid` mode, consent auto-dismiss, stealth, and the CLI daemon's console/network capture. `reload()` ignores `ignoreCache` on Firefox (BiDi limitation).
 - `port: 9222` — Attach to a Chromium already running with `--remote-debugging-port=N` instead of spawning one. The browser keeps running on `close()`. Stealth + permission denial + download capture are skipped to avoid mutating the user's running browser.
 - `proxy: 'http://...'` — HTTP/SOCKS proxy for browser
 - `viewport: '1280x720'` — Set viewport dimensions
 - `storageState: 'file.json'` — Load cookies/localStorage from saved state
+- `incognito: true|false` — Default `false`. When `true`, run a clean, unauthenticated session: skips `storageState` loading AND makes `injectCookies()` a no-op, so no auth ever enters the session even though callers (MCP `goto`, daemon) inject unconditionally. The temp profile is already throwaway; this gates the *other* auth source — the user's real browser cookies. Not Chrome's `--incognito` flag. Surfaced everywhere: library, MCP (`browse` tool param + `BAREBROWSE_INCOGNITO=1` env for the session), CLI (`--incognito`), bareagent (via `connect` opts).
 - `downloadPath: '/abs/dir'` — Where downloads land. Default: per-session `mkdtemp` under `/tmp/barebrowse-dl-*` that gets removed on `close()`. Caller-supplied paths are not cleaned up — caller owns the lifecycle.
 - `blockAds: true|false` — CDP-level URL blocking of 128 common ad/tracker patterns (Google ads/analytics, FB/Amazon/MS/Adobe ad+analytics, Segment/Amplitude/Mixpanel/Heap/PostHog, Hotjar/FullStory/LogRocket, Criteo/Taboola/Outbrain, the consumer-pixel cluster, AppNexus/Rubicon/PubMatic supply, marketing automation; v0.10.1 added AppsFlyer/Branch/Adjust, Cloudflare Web Analytics, Matomo Cloud). Default `true` for launched browsers, `false` in attach mode (would affect any tab in the user's running browser). Explicit `true` in attach mode is honored and follows the session across `switchTab()` (regression-tested). Shrinks ARIA snapshots and speeds page loads. On legacy Chromium lacking `Network.setBlockedURLs` a one-time `console.warn` surfaces the fallback.
 - `blockUrls: ['*://foo.com/*', ...]` — Extra glob patterns (CDP `Network.setBlockedURLs` format) to block in addition to the default. Merged with the default unless `blockAds: false`.

--- a/cli.js
+++ b/cli.js
@@ -112,6 +112,7 @@ async function cmdOpen() {
     mode: parseFlag('--mode') || 'headless',
     port: parseFlag('--port'),
     cookies: !hasFlag('--no-cookies'),
+    incognito: hasFlag('--incognito') || undefined,
     browser: parseFlag('--browser'),
     timeout: parseFlag('--timeout'),
     pruneMode: parseFlag('--prune-mode') || 'act',
@@ -202,7 +203,7 @@ async function oneShot() {
   const url = args[1];
   const mode = args[2] || 'headless';
   try {
-    const snapshot = await browse(url, { mode });
+    const snapshot = await browse(url, { mode, incognito: hasFlag('--incognito') || undefined });
     process.stdout.write(snapshot + '\n');
     process.exit(0);
   } catch (err) {
@@ -218,6 +219,7 @@ async function runDaemonInternal() {
     mode: parseFlag('--mode') || 'headless',
     port: parseFlag('--port'),
     cookies: !hasFlag('--no-cookies'),
+    incognito: hasFlag('--incognito') || undefined,
     browser: parseFlag('--browser'),
     timeout: parseFlag('--timeout'),
     pruneMode: parseFlag('--prune-mode') || 'act',
@@ -488,6 +490,7 @@ Session:
                                     hybrid is chromium-only)
     --port=N                        CDP port for headed mode
     --no-cookies                    Skip cookie injection
+    --incognito                     Clean, unauthenticated session (skip all auth injection)
     --browser=firefox|chromium      Cookie source browser
     --timeout=N                     Navigation timeout in ms
     --prune-mode=act|read           Default pruning mode

--- a/cli.js
+++ b/cli.js
@@ -108,6 +108,7 @@ async function cmdOpen() {
 
   const url = args[1] && !args[1].startsWith('--') ? args[1] : undefined;
   const opts = {
+    engine: parseFlag('--engine'),
     mode: parseFlag('--mode') || 'headless',
     port: parseFlag('--port'),
     cookies: !hasFlag('--no-cookies'),
@@ -213,6 +214,7 @@ async function oneShot() {
 async function runDaemonInternal() {
   const { runDaemon } = await import('./src/daemon.js');
   const opts = {
+    engine: parseFlag('--engine'),
     mode: parseFlag('--mode') || 'headless',
     port: parseFlag('--port'),
     cookies: !hasFlag('--no-cookies'),
@@ -480,7 +482,10 @@ Session:
   barebrowse status                 Check session status
 
   Open flags:
-    --mode=headless|headed|hybrid   Browser mode (default: headless)
+    --engine=chromium|firefox       Browser engine (default: chromium/CDP;
+                                    firefox drives over WebDriver BiDi)
+    --mode=headless|headed|hybrid   Browser mode (default: headless;
+                                    hybrid is chromium-only)
     --port=N                        CDP port for headed mode
     --no-cookies                    Skip cookie injection
     --browser=firefox|chromium      Cookie source browser

--- a/docs/01-product/prd.md
+++ b/docs/01-product/prd.md
@@ -123,6 +123,8 @@ After connection, every CDP command is the same. Three modes = ~20 extra lines i
 - For headed mode, cookies are already present in the browser — no extraction needed.
 - For headless mode, we extract from the user's profile and inject into the headless instance.
 
+**Opt-out — incognito (`incognito: true`):** A clean, unauthenticated session. Skips *all* auth injection — no cookie extraction/injection and no `storageState` — so the agent browses logged-out. (The session profile is already a throwaway temp dir; incognito gates the *other* auth source: the user's real browser cookies. It is not Chrome's `--incognito` flag.) The gate is enforced at the page-object level, so it holds even when a caller injects unconditionally (MCP `goto`, the daemon). Exposed on `browse()`, `connect()`, both engines, MCP (`browse` arg + `BAREBROWSE_INCOGNITO=1`), and CLI (`--incognito`).
+
 **Limitation:** Cookies expire. This works for existing sessions, not new logins. For sites requiring fresh auth, headed mode with user interaction is the fallback.
 
 ### Security Model & Safe Defaults
@@ -138,7 +140,7 @@ After connection, every CDP command is the same. Three modes = ~20 extra lines i
 | **Artifact permissions** | **On.** output dir `0700`, files `0600`, across both the daemon *and* MCP surfaces | Snapshots/articles/screenshots (authenticated content) and `saveState` output (cookies + localStorage = session tokens) must not be world-readable on a multi-user host. Modes are set explicitly, so they hold regardless of the process umask. (The MCP path previously inherited a `0644`/umask default — closed and regression-guarded.) |
 | **MCP `eval`** | **Opt-in** (`BAREBROWSE_MCP_EVAL=1`) | `Runtime.evaluate` in an authenticated session is full access. The agent acts with less judgment than a developer, so the MCP surface gates it; CLI/connect/daemon keep it (developer is the caller) but the daemon now requires the auth token. |
 
-Cookie injection is scoped by a precise RFC-6265 domain match (not a substring `LIKE`), so browsing one site can't pull look-alike or unrelated-eTLD cookies into the session. Every safety control is expressed identically across the library, MCP, bareagent, and CLI surfaces — no entry point is a less-securable path.
+Cookie injection is scoped by a precise RFC-6265 domain match (not a substring `LIKE`), so browsing one site can't pull look-alike or unrelated-eTLD cookies into the session. Both engines share one `scopedCookiesForUrl` (CDP `authenticate` and Firefox/BiDi `injectCookies`) so they cannot drift — the Firefox path scopes to the target host exactly like CDP rather than loading the whole jar. Every safety control is expressed identically across the library, MCP, bareagent, and CLI surfaces — no entry point is a less-securable path.
 
 **Known limitation:** the private-network guard matches the URL hostname; a public DNS name that resolves to a private IP (DNS rebinding) is not caught — that needs connection-time IP inspection.
 
@@ -208,6 +210,7 @@ const tree = await browse('https://example.com');
 const tree = await browse('https://example.com', {
   mode: 'hybrid',        // 'headless' (default) | 'headed' | 'hybrid'
   cookies: true,          // inject user's cookies (default: true)
+  incognito: false,       // clean, unauthenticated session: skip all auth injection
   prune: true,            // apply ARIA pruning (default: true)
   browser: 'chrome',      // which browser profile for cookies
   timeout: 30000,         // navigation timeout ms

--- a/docs/01-product/prd.md
+++ b/docs/01-product/prd.md
@@ -59,9 +59,22 @@ CDP (Chrome DevTools Protocol) lets us connect to any Chromium-based browser —
 - CDP gives us everything: `Accessibility.getFullAXTree`, `Page.navigate`, `Runtime.evaluate`, `Input.dispatch*Event`, `Network.setCookie`, `Page.captureScreenshot`.
 - The CDP WebSocket client is ~165 lines of vanilla JS (over the `ws` package). Playwright is ~50,000.
 
-**What we lose:** Cross-engine support (Firefox, WebKit). CDP only works with Chromium-family browsers (Chrome, Chromium, Edge, Brave, Vivaldi, Arc, Opera). This covers ~80% of desktop browsers. Firefox support could come later via WebDriver BiDi.
+**What we lose:** WebKit/Safari. CDP only works with Chromium-family browsers (Chrome, Chromium, Edge, Brave, Vivaldi, Arc, Opera). Firefox — which deprecated CDP — is now supported through a second transport over the same `ws` dependency (see *BiDi-Direct* below), so the CDP path covers Chromium (~80% of desktop) and BiDi covers Firefox.
 
 **What we gain:** Zero heavy deps, uses the user's real browser, same code path for headless/headed/hybrid, drastically simpler codebase.
+
+### BiDi-Direct (Why Firefox Is Its Own Transport)
+
+**Decision:** Drive Firefox over W3C **WebDriver BiDi**, not CDP — a second transport (`src/bidi.js`) beside the CDP client, selected with `connect({ engine: 'firefox' })`. No geckodriver, no new dependency: BiDi rides the same `ws` WebSocket as CDP.
+
+**Why:**
+- CDP was deprecated in Firefox; BiDi is the W3C-standard successor (and Chrome implements it too, so this is not a Firefox-only detour).
+- A direct BiDi socket at `ws://HOST:PORT/session` speaks `session.new` / `browsingContext.navigate` / `script.evaluate` / `input.performActions` / `storage.setCookie` — a near 1:1 map onto the existing `page.*` surface.
+- Firefox cookies are already extracted by `auth.js` (plaintext SQLite, no keyring) and inject back via `storage.setCookie` — same-engine reuse (Firefox → Firefox), strictly more faithful than the cross-engine cookie path.
+
+**The load-bearing risk — and how it was retired:** BiDi has **no `Accessibility.getFullAXTree`**. The entire value prop (a pruned ARIA snapshot) depends on an AX tree. So Firefox reconstructs a **CDP-vocabulary** AX tree *in-page* via one `script.evaluate` (`src/ax-snapshot.js`): implicit ARIA roles, accessible-name computation, `aria-hidden`/visibility filtering, and shadow-DOM/`<slot>` traversal — emitting the exact `{ nodeId, role, name, properties, children, ignored }` shape `prune.js` and `aria.js` already consume, so both are reused unchanged. A POC proved (measured, not asserted) that a 12k-node page serializes as ~1 MB in ~67 ms and the socket survives — the same large-payload failure that forced the `ws` dependency on the CDP side. Fidelity was validated against real CDP snapshots of identical fixtures; the hard cases (nested iframes with cross-context clicks, open shadow DOM, strict CSP, SPA late-DOM) are covered by `test/integration/firefox.test.js`.
+
+**What we gain:** Firefox as a first-class target, W3C-standard alignment, no bundled driver, and the pruning/formatting/reader pipeline shared verbatim across engines.
 
 ### ARIA-First (Why Not DOM)
 
@@ -268,7 +281,9 @@ This section exists so we don't re-debate settled decisions.
 | Pruning | Built-in | Agents always need pruned output | Optional/separate | Two deps for one job, pruning isn't optional |
 | Cookie auth | Own auth.js + CDP inject | User's existing sessions (Firefox or Chromium), cross-browser injection into headless Chromium | OAuth/credential storage | Complex, security liability, reinventing what the browser already solved |
 | Three modes | One flag | Same CDP code, ~20 lines difference | Separate packages | Same code, artificial separation |
-| Chromium only | CDP constraint | ~80% browser share, user's real browser | Cross-browser (Playwright) | Requires Playwright, loses "use your own browser" benefit |
+| Chromium via CDP | CDP constraint | ~80% browser share, user's real browser | Cross-browser (Playwright) | Requires Playwright, loses "use your own browser" benefit |
+| Firefox via BiDi | `connect({ engine: 'firefox' })` | CDP is deprecated in Firefox; BiDi is the W3C-standard successor. Second transport (`bidi.js`) over the *same* `ws` dep — no geckodriver, no new dependency. Reuses `prune.js`/`aria.js`/`readable.js` verbatim | Playwright / geckodriver / drop Firefox | Playwright = 200MB + abstraction; geckodriver = an extra binary + process; dropping Firefox cedes a real engine |
+| BiDi AX tree | In-page reconstruction (`ax-snapshot.js`) | BiDi has no `getFullAXTree`. Rebuild a CDP-vocabulary tree in one `script.evaluate` (implicit roles, accname, hidden-filtering, shadow-DOM) so pruning/formatting are shared unchanged. POC-measured: 12k nodes → ~1 MB / ~67 ms, socket survives | Native AX API / incremental DOM walk | BiDi exposes no AX API; a naive per-node walk is slow and lossy. Validated against real CDP snapshots |
 | Anti-detection | Runtime.evaluate patches | Minimal stealth for headless mode | Full stealth framework | Over-engineering; headless + real cookies handles 90% |
 | Daemon/server | None | CDP is direct, no intermediary needed | sweetlink daemon pattern | Unnecessary complexity for local agent→browser |
 | Framework | None (vanilla JS) | Matches bare- philosophy, minimal deps (only `ws` + `@mozilla/readability`, both lightweight) | Express/Fastify wrapper | Not a server, not needed |
@@ -298,7 +313,7 @@ This section exists so we don't re-debate settled decisions.
 - **Network interception** — `Fetch.enable` + URL patterns for blocking trackers/ads or mocking responses. Still queued.
 
 ### Medium-term
-- **Firefox support** — Via WebDriver BiDi protocol (cross-browser standard, still maturing). Second protocol adapter alongside CDP.
+- **Firefox support** — *(Done: `connect({ engine: 'firefox' })` drives Firefox over WebDriver BiDi via `bidi.js` + `firefox.js`, with the AX tree reconstructed in-page by `ax-snapshot.js`. Covers `goto`, `snapshot`, `click`, `type`, `press`, `scroll`, `hover`, `select`, `drag`, `upload`, `goBack`/`goForward`, `reload`, `screenshot`, `pdf`, `tabs`/`switchTab`, `waitFor`, `readable`, `injectCookies`, `close`. Selectable from MCP via `BAREBROWSE_ENGINE=firefox` and from the CLI via `barebrowse open --engine firefox`. Verified for accname fidelity, iframes, shadow DOM, CSP, SPA timing, navigation, capture, and the CLI/MCP paths in `test/integration/firefox.test.js` + smoke tests. **Known gaps:** consent auto-dismiss, stealth, and hybrid fallback are chromium-only; accname is a high-value subset of the W3C spec; `reload` can't honour `ignoreCache` (Firefox BiDi doesn't support it yet); and the daemon's console/network capture is CDP-only, so those logs are empty for a Firefox session.)*
 - **Cookie sync** — In hybrid mode, extract fresh cookies from headed session and cache for future headless use. Self-refreshing auth.
 - **Selector discovery** — Port sweetlink's `discoverSelectors` — crawl ARIA tree, score interactive elements, return ranked action targets.
 - **Form understanding** — Detect forms in ARIA tree, map fields to semantic purposes, enable agents to fill forms intelligently.

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -121,7 +121,14 @@ let _pageConnecting = null;
 async function getPage() {
   if (_page) return _page;
   if (_pageConnecting) return _pageConnecting;
-  _pageConnecting = connect({ mode: 'hybrid' });
+  // Engine selection is a launch-time setting (the browser persists across
+  // tool calls), so it's an env var, not a per-request flag. Firefox is driven
+  // over WebDriver BiDi and has no hybrid fallback — default it to headless
+  // (override with BAREBROWSE_MODE=headed).
+  const connectOpts = process.env.BAREBROWSE_ENGINE === 'firefox'
+    ? { engine: 'firefox', mode: process.env.BAREBROWSE_MODE || 'headless' }
+    : { mode: 'hybrid' };
+  _pageConnecting = connect(connectOpts);
   try {
     _page = await _pageConnecting;
     return _page;

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -125,9 +125,13 @@ async function getPage() {
   // tool calls), so it's an env var, not a per-request flag. Firefox is driven
   // over WebDriver BiDi and has no hybrid fallback — default it to headless
   // (override with BAREBROWSE_MODE=headed).
+  // Incognito is a launch-time setting like engine/mode: the session persists
+  // across tool calls, so it's an env var (BAREBROWSE_INCOGNITO=1), not a
+  // per-request flag. Skips all auth injection for a clean, logged-out session.
+  const incognito = process.env.BAREBROWSE_INCOGNITO === '1';
   const connectOpts = process.env.BAREBROWSE_ENGINE === 'firefox'
-    ? { engine: 'firefox', mode: process.env.BAREBROWSE_MODE || 'headless' }
-    : { mode: 'hybrid' };
+    ? { engine: 'firefox', mode: process.env.BAREBROWSE_MODE || 'headless', incognito }
+    : { mode: 'hybrid', incognito };
   _pageConnecting = connect(connectOpts);
   try {
     _page = await _pageConnecting;
@@ -163,6 +167,7 @@ export const TOOLS = [
         url: { type: 'string', description: 'URL to browse' },
         mode: { type: 'string', enum: ['headless', 'headed', 'hybrid'], description: 'Browser mode (default: headless)' },
         pruneMode: { type: 'string', enum: ['act', 'read'], description: 'Pruning mode. "act" (default) keeps interactive elements and short labels — best for clicking/filling. "read" keeps paragraphs, headings, and long text — best for articles, docs, and content extraction. If the page is content-heavy and act-mode returns mostly empty, retry with "read".' },
+        incognito: { type: 'boolean', description: 'Clean, unauthenticated session: skip cookie injection so the page loads logged-out (default: false).' },
         maxChars: { type: 'number', description: 'Max chars to return inline. Larger snapshots are saved to .barebrowse/ and a file path is returned instead. Default: 30000.' },
       },
       required: ['url'],
@@ -398,7 +403,7 @@ async function handleToolCall(name, args) {
     case 'browse': {
       let timer;
       const text = await Promise.race([
-        browse(args.url, { mode: args.mode, pruneMode: args.pruneMode }),
+        browse(args.url, { mode: args.mode, pruneMode: args.pruneMode, incognito: args.incognito }),
         new Promise((_, rej) => { timer = setTimeout(() => rej(new Error('browse timed out after 60s')), 60000); }),
       ]);
       clearTimeout(timer);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "barebrowse",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "barebrowse",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "barebrowse",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Authenticated web browsing for autonomous agents via CDP. URL in, pruned ARIA snapshot out.",
   "repository": {
     "type": "git",

--- a/src/auth.js
+++ b/src/auth.js
@@ -288,25 +288,39 @@ export function cookieDomainMatch(host, cookieDomain) {
 }
 
 /**
+ * Select the user's cookies that are in-scope for `url`. Shared by BOTH engines
+ * (CDP `authenticate` and Firefox/BiDi `injectCookies`) so they can't drift on
+ * scoping — a divergence here re-opens loading the entire cookie jar into an
+ * agent session. Returns the filtered cookie array; never injects.
+ *
+ * Coarse SQL pre-filter strips to a registrable-ish domain so the LIKE query
+ * returns a superset (incl. parent-domain cookies). slice(-2) is a cheap
+ * heuristic — it over-selects for multi-part eTLDs (co.uk) and as a substring
+ * match, so the precise RFC-6265 domain-match is what actually decides which
+ * cookies pass. Without it, browsing apple.com would match apple.com.evil.org
+ * and every *.co.uk site (verified).
+ * @param {string} url - URL whose host the cookies must match
+ * @param {object} [opts] - passed to extractCookies (e.g. { browser })
+ * @returns {Array<object>} cookies whose domain matches the URL host
+ */
+export function scopedCookiesForUrl(url, opts = {}) {
+  const fullHost = new URL(url).hostname.toLowerCase();
+  const noWww = fullHost.replace(/^www\./, '');
+  const parts = noWww.split('.');
+  const coarseDomain = parts.length > 2 ? parts.slice(-2).join('.') : noWww;
+  const candidates = extractCookies({ ...opts, domain: coarseDomain });
+  return candidates.filter((c) => cookieDomainMatch(fullHost, c.domain));
+}
+
+/**
  * Extract cookies for a URL and inject them into a CDP session.
- * Convenience function combining extractCookies + injectCookies.
+ * Convenience function combining scopedCookiesForUrl + injectCookies.
  * @param {object} session - CDP session handle
  * @param {string} url - URL to extract cookies for
  * @param {object} [opts] - Options passed to extractCookies
  */
 export async function authenticate(session, url, opts = {}) {
-  const fullHost = new URL(url).hostname.toLowerCase();
-  // Coarse SQL pre-filter: strip to a registrable-ish domain so the LIKE query
-  // returns a superset (incl. parent-domain cookies). slice(-2) is a cheap
-  // heuristic — it over-selects for multi-part eTLDs (co.uk) and as a substring
-  // match, so the precise RFC-6265 domain-match below is what actually decides
-  // which cookies get injected. Without it, browsing apple.com would inject
-  // cookies for apple.com.evil.org and every *.co.uk site (verified).
-  const noWww = fullHost.replace(/^www\./, '');
-  const parts = noWww.split('.');
-  const coarseDomain = parts.length > 2 ? parts.slice(-2).join('.') : noWww;
-  const candidates = extractCookies({ ...opts, domain: coarseDomain });
-  const cookies = candidates.filter((c) => cookieDomainMatch(fullHost, c.domain));
+  const cookies = scopedCookiesForUrl(url, opts);
   if (cookies.length > 0) {
     await injectCookies(session, cookies);
   }

--- a/src/ax-snapshot.js
+++ b/src/ax-snapshot.js
@@ -1,3 +1,8 @@
+// @ts-nocheck — AX_FN below is browser-context code (document, getComputedStyle,
+// CSS, real regex literals) serialized via .toString() and run inside Firefox,
+// never in Node. tsc's Node lib (no DOM) can't meaningfully check it, and the
+// readable.js string convention would corrupt its regex backslashes, so the
+// file opts out of type-checking. The Node-side exports are trivial.
 /**
  * ax-snapshot.js — Reconstruct a CDP-shaped accessibility tree in-page.
  *

--- a/src/ax-snapshot.js
+++ b/src/ax-snapshot.js
@@ -1,0 +1,269 @@
+/**
+ * ax-snapshot.js — Reconstruct a CDP-shaped accessibility tree in-page.
+ *
+ * CDP hands you Accessibility.getFullAXTree; BiDi has no equivalent, so on
+ * Firefox we rebuild an equivalent tree inside the page via script.evaluate.
+ * The output tree uses the SAME node shape and role vocabulary as
+ * buildTree()'s CDP output, so prune.js and aria.js consume it unchanged:
+ *
+ *   { nodeId, role, name, properties, children, ignored }
+ *
+ * where `role` is CDP/ARIA vocabulary ('RootWebArea', 'StaticText', 'heading',
+ * 'link', 'button', 'img', 'paragraph', 'list', 'navigation', …), NOT tag
+ * names. The three things getFullAXTree gave us for free and we reimplement:
+ *   1. implicit ARIA role mapping (HTML element → role)
+ *   2. accessible-name computation (aria-labelledby → aria-label → native
+ *      label/alt/legend/title → text content) — the POC proved textContent
+ *      alone is NOT enough (img alt, <label>, aria-labelledby all missed).
+ *   3. hidden-subtree filtering (aria-hidden, display:none, visibility:hidden,
+ *      the hidden attribute).
+ *
+ * Each kept element is tagged with a data-bb-ref attribute carrying its ref,
+ * so interact-bidi.js can resolve a ref back to its element via querySelector.
+ * Refs are assigned from a caller-supplied `base` so they stay globally unique
+ * across browsing contexts (iframes), matching CDP's flat integer refs.
+ */
+
+/** Attribute used to tag elements for ref → element resolution. */
+export const REF_ATTR = 'data-bb-ref';
+
+/**
+ * The in-page reconstruction function, as source text. Evaluated in a browsing
+ * context with a `base` ref offset; returns JSON { tree, count }. Written as a
+ * single self-contained function (no closures over module scope) because it
+ * runs in the page, not in Node.
+ */
+const AX_FN = function reconstructAX(base, REF_ATTR) {
+  let ref = base;
+
+  // Roles whose accessible name comes from descendant text (so we must NOT
+  // also emit child StaticText nodes — CDP folds the text into the name).
+  const NAME_FROM_CONTENT = new Set([
+    'button', 'link', 'heading', 'cell', 'columnheader', 'rowheader',
+    'tab', 'menuitem', 'option', 'treeitem', 'switch', 'checkbox', 'radio',
+  ]);
+
+  // HTML tag → implicit ARIA role (the common, high-value subset).
+  const TAG_ROLE = {
+    A: (el) => (el.hasAttribute('href') ? 'link' : 'generic'),
+    BUTTON: () => 'button',
+    NAV: () => 'navigation', MAIN: () => 'main', ASIDE: () => 'complementary',
+    HEADER: (el) => (isTopLevelLandmark(el) ? 'banner' : 'generic'),
+    FOOTER: (el) => (isTopLevelLandmark(el) ? 'contentinfo' : 'generic'),
+    FORM: () => 'form', SEARCH: () => 'search',
+    SECTION: (el) => (accName(el) ? 'region' : 'generic'),
+    ARTICLE: () => 'article',
+    H1: () => 'heading', H2: () => 'heading', H3: () => 'heading',
+    H4: () => 'heading', H5: () => 'heading', H6: () => 'heading',
+    P: () => 'paragraph',
+    UL: () => 'list', OL: () => 'list', LI: () => 'listitem',
+    DL: () => 'list', DT: () => 'term', DD: () => 'definition',
+    IMG: (el) => (el.getAttribute('alt') === '' ? 'none' : 'image'),
+    FIGURE: () => 'figure', FIGCAPTION: () => 'Figcaption',
+    TABLE: () => 'table', TR: () => 'row', TD: () => 'cell',
+    TH: (el) => (el.getAttribute('scope') === 'row' ? 'rowheader' : 'columnheader'),
+    THEAD: () => 'rowgroup', TBODY: () => 'rowgroup', TFOOT: () => 'rowgroup',
+    SELECT: (el) => (el.multiple ? 'listbox' : 'combobox'),
+    TEXTAREA: () => 'textbox',
+    OPTION: () => 'option',
+    LABEL: () => 'LabelText', SPAN: () => 'generic', DIV: () => 'generic',
+    STRONG: () => 'strong', EM: () => 'emphasis', B: () => 'strong', I: () => 'emphasis',
+    BLOCKQUOTE: () => 'blockquote', CODE: () => 'code', PRE: () => 'generic',
+    HR: () => 'separator',
+    IFRAME: () => 'Iframe', FRAME: () => 'Iframe',
+    INPUT: (el) => {
+      const t = (el.getAttribute('type') || 'text').toLowerCase();
+      return ({
+        button: 'button', submit: 'button', reset: 'button', image: 'button',
+        checkbox: 'checkbox', radio: 'radio', range: 'slider',
+        search: 'searchbox', email: 'textbox', tel: 'textbox', url: 'textbox',
+        text: 'textbox', password: 'textbox', number: 'spinbutton',
+        hidden: 'none',
+      })[t] || 'textbox';
+    },
+  };
+
+  function isTopLevelLandmark(el) {
+    // <header>/<footer> are landmarks only when not scoped inside article/section/main/aside.
+    for (let p = el.parentElement; p; p = p.parentElement) {
+      if (/^(ARTICLE|SECTION|MAIN|ASIDE|NAV)$/.test(p.tagName)) return false;
+    }
+    return true;
+  }
+
+  function roleOf(el) {
+    const explicit = el.getAttribute('role');
+    if (explicit) return explicit.trim().split(/\s+/)[0];
+    const fn = TAG_ROLE[el.tagName];
+    return fn ? fn(el) : 'generic';
+  }
+
+  function isHidden(el) {
+    if (el.getAttribute('aria-hidden') === 'true') return true;
+    if (el.hasAttribute('hidden')) return true;
+    const s = getComputedStyle(el);
+    if (s.display === 'none' || s.visibility === 'hidden' || s.visibility === 'collapse') return true;
+    return false;
+  }
+
+  // Accessible-name computation (compact subset of the accname spec, covering
+  // the cases the POC proved textContent misses).
+  function accName(el, depth) {
+    depth = depth || 0;
+    // 1. aria-labelledby (resolve id refs → their text)
+    const lb = el.getAttribute && el.getAttribute('aria-labelledby');
+    if (lb && depth < 2) {
+      const txt = lb.split(/\s+/).map((id) => {
+        const t = document.getElementById(id);
+        return t ? accName(t, depth + 1) || t.textContent.trim() : '';
+      }).filter(Boolean).join(' ').trim();
+      if (txt) return txt;
+    }
+    // 2. aria-label
+    const al = el.getAttribute && el.getAttribute('aria-label');
+    if (al && al.trim()) return al.trim();
+    const tag = el.tagName;
+    // 3. native naming
+    if (tag === 'IMG' || tag === 'AREA') {
+      const alt = el.getAttribute('alt');
+      if (alt) return alt.trim();
+    }
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+      // associated <label> (for= or wrapping ancestor)
+      if (el.id) {
+        const lab = document.querySelector('label[for="' + CSS.escape(el.id) + '"]');
+        if (lab) return lab.textContent.trim();
+      }
+      const wrap = el.closest && el.closest('label');
+      if (wrap) return wrap.textContent.trim();
+      const ph = el.getAttribute('placeholder');
+      if (ph && ph.trim()) return ph.trim();
+    }
+    if (tag === 'FIELDSET') {
+      const lg = el.querySelector && el.querySelector('legend');
+      if (lg) return lg.textContent.trim();
+    }
+    if (tag === 'TABLE') {
+      const cap = el.querySelector && el.querySelector('caption');
+      if (cap) return cap.textContent.trim();
+    }
+    // 4. title attribute
+    const title = el.getAttribute && el.getAttribute('title');
+    if (title && title.trim()) return title.trim();
+    return '';
+  }
+
+  function props(el, role) {
+    const p = {};
+    if (role === 'checkbox' || role === 'radio' || role === 'switch') p.checked = !!el.checked;
+    if (el.disabled || el.getAttribute('aria-disabled') === 'true') p.disabled = true;
+    const exp = el.getAttribute('aria-expanded');
+    if (exp !== null) p.expanded = exp === 'true';
+    if (role === 'heading') p.level = Number(el.getAttribute('aria-level')) || Number(el.tagName[1]) || 2;
+    if (el.getAttribute('aria-selected') === 'true') p.selected = true;
+    if (el.required || el.getAttribute('aria-required') === 'true') p.required = true;
+    if ((role === 'textbox' || role === 'searchbox' || role === 'combobox' || role === 'spinbutton') && el.value) {
+      p.value = el.value;
+    }
+    return p;
+  }
+
+  function makeNode(role, name, properties) {
+    return { nodeId: String(++ref), role, name: name || '', properties: properties || {}, children: [], ignored: false };
+  }
+
+  // Walk a DOM element → AX node (or null if hidden/irrelevant). Text runs
+  // become StaticText children unless the parent names from content.
+  function walk(el) {
+    if (isHidden(el)) return null;
+    let role = roleOf(el);
+    if (role === 'none') return collapseChildren(el); // presentational: keep kids
+
+    // Accessible name: explicit sources first, then fall back to descendant
+    // text for roles that name from content (button/link/heading/…), matching
+    // CDP — otherwise those nodes come back nameless.
+    let name = accName(el);
+    if (!name && NAME_FROM_CONTENT.has(role)) {
+      name = el.textContent.replace(/\s+/g, ' ').trim();
+    }
+    const node = makeNode(role, name, props(el, role));
+    el.setAttribute(REF_ATTR, node.nodeId);
+
+    if (!NAME_FROM_CONTENT.has(role)) {
+      for (const child of kidsOf(el)) {
+        if (child.nodeType === 3) {
+          const t = child.textContent.replace(/\s+/g, ' ').trim();
+          if (t) node.children.push(makeNode('StaticText', t, {}));
+        } else if (child.nodeType === 1) {
+          const c = walk(child);
+          if (c) Array.isArray(c) ? node.children.push(...c) : node.children.push(c);
+        }
+      }
+    } else {
+      // name-from-content: still recurse into element children for nested
+      // interactives (e.g. a link inside a heading), but drop bare text.
+      for (const child of kidsOf(el)) {
+        if (child.nodeType !== 1) continue;
+        const c = walk(child);
+        if (c) Array.isArray(c) ? node.children.push(...c) : node.children.push(c);
+      }
+    }
+    return node;
+  }
+
+  // Effective children to traverse: shadow-root content when the element hosts
+  // an open shadow tree (that is what actually renders — CDP's AX tree includes
+  // it), assigned light nodes for a <slot>, else plain light-DOM childNodes.
+  function kidsOf(el) {
+    if (el.tagName === 'SLOT') {
+      const assigned = el.assignedNodes ? el.assignedNodes({ flatten: true }) : [];
+      return assigned.length ? assigned : [...el.childNodes];
+    }
+    if (el.shadowRoot) return [...el.shadowRoot.childNodes];
+    return [...el.childNodes];
+  }
+
+  // Presentational element (role=none/presentation): emit its children only.
+  function collapseChildren(el) {
+    const out = [];
+    for (const child of kidsOf(el)) {
+      if (child.nodeType === 3) {
+        const t = child.textContent.replace(/\s+/g, ' ').trim();
+        if (t) out.push(makeNode('StaticText', t, {}));
+      } else if (child.nodeType === 1 && !isHidden(child)) {
+        const c = walk(child);
+        if (c) Array.isArray(c) ? out.push(...c) : out.push(c);
+      }
+    }
+    return out;
+  }
+
+  // Clear stale refs from a prior snapshot so resolution never hits a ghost.
+  for (const old of document.querySelectorAll('[' + REF_ATTR + ']')) old.removeAttribute(REF_ATTR);
+
+  // Wrap body content in an ignored 'none' node, mirroring the html/body
+  // wrappers CDP's getFullAXTree emits. prune.js's region extraction only
+  // inspects RootWebArea's DIRECT children for landmarks, so without this
+  // wrapper a top-level <form>/<nav> (no <main>) would be treated as a
+  // directly-extractable region and dropped in act mode — a divergence from
+  // CDP, where the same landmark is buried under body and flows through.
+  const root = makeNode('RootWebArea', document.title || '', {});
+  const body = makeNode('none', '', {});
+  body.ignored = true;
+  for (const child of document.body ? document.body.children : []) {
+    const c = walk(child);
+    if (c) Array.isArray(c) ? body.children.push(...c) : body.children.push(c);
+  }
+  root.children.push(body);
+  return JSON.stringify({ tree: root, count: ref - base });
+};
+
+/**
+ * Build the script.evaluate expression that reconstructs the AX tree in a
+ * context, assigning refs from `base`.
+ * @param {number} base - Starting ref offset (exclusive; first ref is base+1)
+ * @returns {string} JS expression returning JSON { tree, count }
+ */
+export function axSnapshotExpression(base) {
+  return `(${AX_FN.toString()})(${Number(base)}, ${JSON.stringify(REF_ATTR)})`;
+}

--- a/src/ax-snapshot.js
+++ b/src/ax-snapshot.js
@@ -24,7 +24,8 @@
  *      the hidden attribute).
  *
  * Each kept element is tagged with a data-bb-ref attribute carrying its ref,
- * so interact-bidi.js can resolve a ref back to its element via querySelector.
+ * so firefox-page.js (resolveRef) can resolve a ref back to its element via
+ * querySelector.
  * Refs are assigned from a caller-supplied `base` so they stay globally unique
  * across browsing contexts (iframes), matching CDP's flat integer refs.
  */

--- a/src/ax-snapshot.js
+++ b/src/ax-snapshot.js
@@ -195,6 +195,11 @@ const AX_FN = function reconstructAX(base, REF_ATTR) {
     const node = makeNode(role, name, props(el, role));
     el.setAttribute(REF_ATTR, node.nodeId);
 
+    // A collapsed native <select> exposes its current value via props/name;
+    // don't expand its <option> list into the tree (a 200-item country select
+    // would otherwise flood every snapshot). A multi/size listbox keeps them.
+    if (el.tagName === 'SELECT' && !el.multiple) return node;
+
     if (!NAME_FROM_CONTENT.has(role)) {
       for (const child of kidsOf(el)) {
         if (child.nodeType === 3) {
@@ -256,9 +261,16 @@ const AX_FN = function reconstructAX(base, REF_ATTR) {
   const root = makeNode('RootWebArea', document.title || '', {});
   const body = makeNode('none', '', {});
   body.ignored = true;
-  for (const child of document.body ? document.body.children : []) {
-    const c = walk(child);
-    if (c) Array.isArray(c) ? body.children.push(...c) : body.children.push(c);
+  // childNodes (not .children) so bare text directly under <body> is kept as
+  // StaticText, matching walk()/CDP; .children would silently drop it.
+  for (const child of document.body ? document.body.childNodes : []) {
+    if (child.nodeType === 3) {
+      const t = child.textContent.replace(/\s+/g, ' ').trim();
+      if (t) body.children.push(makeNode('StaticText', t, {}));
+    } else if (child.nodeType === 1) {
+      const c = walk(child);
+      if (c) Array.isArray(c) ? body.children.push(...c) : body.children.push(c);
+    }
   }
   root.children.push(body);
   return JSON.stringify({ tree: root, count: ref - base });

--- a/src/bidi.js
+++ b/src/bidi.js
@@ -1,0 +1,142 @@
+/**
+ * bidi.js — Minimal WebDriver BiDi client over WebSocket (Firefox transport).
+ *
+ * The W3C-standard successor to CDP. CDP was deprecated in Firefox, so Firefox
+ * is driven over BiDi instead. This is the BiDi analogue of cdp.js: same
+ * JSON-RPC-over-WebSocket shape (id/method/params → result), same `ws`
+ * dependency and 256 MB maxPayload (a full AX snapshot of a large page is
+ * returned as one big string from script.evaluate — see ax-snapshot.js — and
+ * would blow the built-in WebSocket cap exactly as getFullAXTree did on CDP).
+ *
+ * Differences from CDP that shape this client:
+ *   - A session must be created explicitly (`session.new`) before any command.
+ *   - Events must be subscribed to (`session.subscribe`); we lean on
+ *     command results (navigate's `wait:'complete'`) instead where possible.
+ *   - Errors arrive as `{ type:'error', error, message }`, not `{ error:{} }`.
+ *   - Everything is scoped by `context` (a browsing-context id), not sessionId.
+ */
+
+import WebSocket from 'ws';
+
+/** Lift the message ceiling well past any realistic AX/DOM payload. */
+const MAX_PAYLOAD = 256 * 1024 * 1024; // 256 MB
+
+/**
+ * Create a BiDi client connected to the given /session WebSocket URL and open
+ * a session. Firefox prints its BiDi endpoint to stderr as
+ * "WebDriver BiDi listening on ws://HOST:PORT"; the direct-connection socket
+ * (no WebDriver-classic handshake) lives at that URL + "/session".
+ *
+ * @param {string} wsUrl - BiDi session WebSocket URL (ws://HOST:PORT/session)
+ * @returns {Promise<object>} BiDi client ({ send, evaluate, on, once, subscribe, sessionId, close })
+ */
+export async function createBiDi(wsUrl) {
+  const ws = new WebSocket(wsUrl, { maxPayload: MAX_PAYLOAD, perMessageDeflate: false });
+  let nextId = 1;
+  const pending = new Map();   // id → { resolve, reject }
+  const listeners = new Map(); // "method" → Set<callback>
+
+  const connected = new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('BiDi connection timeout (5s)')), 5000);
+    ws.onopen = () => { clearTimeout(timeout); resolve(); };
+    ws.onerror = (e) => {
+      clearTimeout(timeout);
+      reject(new Error(`BiDi WebSocket connection failed: ${e.message || 'unknown error'}`));
+    };
+  });
+  await connected;
+
+  ws.onmessage = (event) => {
+    const msg = JSON.parse(typeof event.data === 'string' ? event.data : event.data.toString());
+
+    // Command response (has id + type 'success' | 'error')
+    if (msg.id !== undefined && pending.has(msg.id)) {
+      const handler = pending.get(msg.id);
+      pending.delete(msg.id);
+      if (msg.type === 'error') {
+        handler.reject(new Error(`BiDi error: ${msg.error} — ${msg.message || ''}`.trim()));
+      } else {
+        handler.resolve(msg.result);
+      }
+      return;
+    }
+
+    // Event (type 'event', has method + params)
+    if (msg.type === 'event' && msg.method) {
+      const set = listeners.get(msg.method);
+      if (set) for (const cb of set) cb(msg.params);
+    }
+  };
+
+  ws.onclose = () => {
+    for (const [id, handler] of pending) {
+      handler.reject(new Error('BiDi WebSocket closed'));
+      pending.delete(id);
+    }
+  };
+
+  const client = {
+    /**
+     * Send a BiDi command and wait for its result.
+     * @param {string} method - e.g. 'browsingContext.navigate'
+     * @param {object} [params]
+     * @returns {Promise<object>} result
+     */
+    send(method, params = {}) {
+      const id = nextId++;
+      return new Promise((resolve, reject) => {
+        pending.set(id, { resolve, reject });
+        ws.send(JSON.stringify({ id, method, params }));
+      });
+    },
+
+    /**
+     * Evaluate an expression in a browsing context and return its value.
+     * Throws on an in-page exception (BiDi reports these as a `success`
+     * envelope with `type:'exception'`, unlike a protocol error).
+     * @param {string} context - browsing-context id
+     * @param {string} expression - JS source to evaluate
+     * @param {boolean} [awaitPromise=true]
+     * @returns {Promise<*>} the deserialized primitive value (result.value)
+     */
+    async evaluate(context, expression, awaitPromise = true) {
+      const res = await client.send('script.evaluate', {
+        expression, target: { context }, awaitPromise,
+      });
+      if (res.type === 'exception') {
+        const d = res.exceptionDetails;
+        throw new Error(`BiDi script exception: ${d?.text || d?.exception?.value || 'unknown'}`);
+      }
+      return res.result?.value;
+    },
+
+    /** Subscribe to BiDi events by method name (required before events fire). */
+    async subscribe(events) {
+      await client.send('session.subscribe', { events });
+    },
+
+    /** Register an event listener. Returns an unsubscribe function. */
+    on(method, callback) {
+      if (!listeners.has(method)) listeners.set(method, new Set());
+      listeners.get(method).add(callback);
+      return () => listeners.get(method)?.delete(callback);
+    },
+
+    /** Resolve once a named event fires (or reject on timeout). */
+    once(method, timeout = 30000) {
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => { unsub(); reject(new Error(`Timeout waiting for BiDi event: ${method}`)); }, timeout);
+        const unsub = client.on(method, (params) => { clearTimeout(timer); unsub(); resolve(params); });
+      });
+    },
+
+    sessionId: null,
+    close() { ws.close(); },
+  };
+
+  // Open the session. capabilities:{} accepts Firefox's defaults.
+  const session = await client.send('session.new', { capabilities: {} });
+  client.sessionId = session.sessionId;
+  client.capabilities = session.capabilities;
+  return client;
+}

--- a/src/bidi.js
+++ b/src/bidi.js
@@ -36,6 +36,7 @@ export async function createBiDi(wsUrl) {
   const pending = new Map();   // id → { resolve, reject }
   const listeners = new Map(); // "method" → Set<callback>
 
+  /** @type {Promise<void>} */
   const connected = new Promise((resolve, reject) => {
     const timeout = setTimeout(() => reject(new Error('BiDi connection timeout (5s)')), 5000);
     ws.onopen = () => { clearTimeout(timeout); resolve(); };

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -46,6 +46,7 @@ export async function startDaemon(opts, outputDir, initialUrl) {
   const args = [join(import.meta.dirname, '..', 'cli.js'), '--daemon-internal'];
   args.push('--output-dir', absDir);
   if (initialUrl) args.push('--url', initialUrl);
+  if (opts.engine) args.push('--engine', opts.engine);
   if (opts.mode) args.push('--mode', opts.mode);
   if (opts.port) args.push('--port', String(opts.port));
   if (opts.cookies === false) args.push('--no-cookies');
@@ -104,6 +105,7 @@ export async function runDaemon(opts, outputDir, initialUrl) {
 
   // Connect to browser
   const page = await connect({
+    engine: opts.engine,
     mode: opts.mode || 'headless',
     port: opts.port ? Number(opts.port) : undefined,
     consent: opts.consent,
@@ -117,53 +119,58 @@ export async function runDaemon(opts, outputDir, initialUrl) {
     uploadDir: opts.uploadDir,
   });
 
-  // Console log capture
+  // Console + network log capture is CDP-specific (page.cdp). The Firefox/BiDi
+  // engine exposes page.bidi instead, so these captures are skipped there —
+  // console-logs / network-log commands return empty for a Firefox session.
+  // (BiDi log.entryAdded / network.* events could back these later.)
   const consoleLogs = [];
-  await page.cdp.send('Runtime.enable');
-  page.cdp.on('Runtime.consoleAPICalled', (params) => {
-    consoleLogs.push({
-      type: params.type,
-      timestamp: new Date().toISOString(),
-      args: params.args.map((a) => a.value ?? a.description ?? a.type),
-    });
-  });
-
-  // Network log capture (Network.enable already called by connect)
   const networkLogs = [];
   const pendingRequests = new Map();
 
-  page.cdp.on('Network.requestWillBeSent', (params) => {
-    pendingRequests.set(params.requestId, {
-      url: params.request.url,
-      method: params.request.method,
-      timestamp: new Date().toISOString(),
+  if (page.cdp) {
+    await page.cdp.send('Runtime.enable');
+    page.cdp.on('Runtime.consoleAPICalled', (params) => {
+      consoleLogs.push({
+        type: params.type,
+        timestamp: new Date().toISOString(),
+        args: params.args.map((a) => a.value ?? a.description ?? a.type),
+      });
     });
-  });
 
-  page.cdp.on('Network.responseReceived', (params) => {
-    const req = pendingRequests.get(params.requestId);
-    if (req) {
-      networkLogs.push({
-        ...req,
-        status: params.response.status,
-        statusText: params.response.statusText,
-        mimeType: params.response.mimeType,
+    // Network log capture (Network.enable already called by connect)
+    page.cdp.on('Network.requestWillBeSent', (params) => {
+      pendingRequests.set(params.requestId, {
+        url: params.request.url,
+        method: params.request.method,
+        timestamp: new Date().toISOString(),
       });
-      pendingRequests.delete(params.requestId);
-    }
-  });
+    });
 
-  page.cdp.on('Network.loadingFailed', (params) => {
-    const req = pendingRequests.get(params.requestId);
-    if (req) {
-      networkLogs.push({
-        ...req,
-        status: 0,
-        error: params.errorText,
-      });
-      pendingRequests.delete(params.requestId);
-    }
-  });
+    page.cdp.on('Network.responseReceived', (params) => {
+      const req = pendingRequests.get(params.requestId);
+      if (req) {
+        networkLogs.push({
+          ...req,
+          status: params.response.status,
+          statusText: params.response.statusText,
+          mimeType: params.response.mimeType,
+        });
+        pendingRequests.delete(params.requestId);
+      }
+    });
+
+    page.cdp.on('Network.loadingFailed', (params) => {
+      const req = pendingRequests.get(params.requestId);
+      if (req) {
+        networkLogs.push({
+          ...req,
+          status: 0,
+          error: params.errorText,
+        });
+        pendingRequests.delete(params.requestId);
+      }
+    });
+  }
 
   // Navigate to initial URL if provided
   if (initialUrl) {
@@ -316,6 +323,15 @@ export async function runDaemon(opts, outputDir, initialUrl) {
     },
 
     async eval({ expression }) {
+      // Firefox/BiDi has no page.cdp — evaluate over BiDi in the active context.
+      if (!page.cdp) {
+        try {
+          const value = await page.bidi.evaluate(page.context, expression, true);
+          return { ok: true, value };
+        } catch (err) {
+          return { ok: false, error: err.message || 'eval error' };
+        }
+      }
       const result = await page.cdp.send('Runtime.evaluate', {
         expression,
         returnByValue: true,

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -346,8 +346,13 @@ export async function runDaemon(opts, outputDir, initialUrl) {
       // Firefox/BiDi has no page.cdp — evaluate over BiDi in the active context.
       if (!page.cdp) {
         try {
-          const value = await page.bidi.evaluate(page.context, expression, true);
-          return { ok: true, value };
+          // BiDi's raw result.value serializes objects into a {type,value}
+          // entries structure, not a plain object (CDP's returnByValue does).
+          // Stringify + parse in-page so an object/array eval matches the CDP
+          // shape (same trick readable() uses). `undefined` → JSON `null`.
+          const wrapped = `(async () => { const v = await (${expression}); return JSON.stringify(v === undefined ? null : v); })()`;
+          const raw = await page.bidi.evaluate(page.context, wrapped, true);
+          return { ok: true, value: raw == null ? null : JSON.parse(raw) };
         } catch (err) {
           return { ok: false, error: err.message || 'eval error' };
         }

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -31,25 +31,25 @@ function tokenMatches(expected, got) {
 const SESSION_FILE = 'session.json';
 
 /**
- * Spawn a detached child process that runs the daemon.
- * Parent polls for session.json, then exits.
+ * Build the argv for the detached daemon child. Pure + exported so the
+ * flag-forwarding contract is unit-testable: a forward that's silently
+ * dropped here (as `--incognito` was in v0.15.0, turning `open --incognito`
+ * into a fully-authenticated session) becomes a failing test, not a leak.
+ * @param {object} opts - the session options parsed in cli.js cmdOpen
+ * @param {string} absDir - resolved output directory
+ * @param {string|undefined} initialUrl - URL to navigate on start (may be undefined)
+ * @param {string} cliPath - path to cli.js for the child to run
+ * @returns {string[]}
  */
-export async function startDaemon(opts, outputDir, initialUrl) {
-  const absDir = resolve(outputDir);
-  mkdirSync(absDir, { recursive: true, mode: 0o700 });
-
-  // Clean stale session
-  const sessionPath = join(absDir, SESSION_FILE);
-  if (existsSync(sessionPath)) unlinkSync(sessionPath);
-
-  // Build child args
-  const args = [join(import.meta.dirname, '..', 'cli.js'), '--daemon-internal'];
+export function buildDaemonArgs(opts, absDir, initialUrl, cliPath) {
+  const args = [cliPath, '--daemon-internal'];
   args.push('--output-dir', absDir);
   if (initialUrl) args.push('--url', initialUrl);
   if (opts.engine) args.push('--engine', opts.engine);
   if (opts.mode) args.push('--mode', opts.mode);
   if (opts.port) args.push('--port', String(opts.port));
   if (opts.cookies === false) args.push('--no-cookies');
+  if (opts.incognito) args.push('--incognito');
   if (opts.browser) args.push('--browser', opts.browser);
   if (opts.timeout) args.push('--timeout', String(opts.timeout));
   if (opts.pruneMode) args.push('--prune-mode', opts.pruneMode);
@@ -64,6 +64,23 @@ export async function startDaemon(opts, outputDir, initialUrl) {
   }
   if (opts.blockPrivateNetwork) args.push('--block-private-network');
   if (opts.uploadDir) args.push('--upload-dir', opts.uploadDir);
+  return args;
+}
+
+/**
+ * Spawn a detached child process that runs the daemon.
+ * Parent polls for session.json, then exits.
+ */
+export async function startDaemon(opts, outputDir, initialUrl) {
+  const absDir = resolve(outputDir);
+  mkdirSync(absDir, { recursive: true, mode: 0o700 });
+
+  // Clean stale session
+  const sessionPath = join(absDir, SESSION_FILE);
+  if (existsSync(sessionPath)) unlinkSync(sessionPath);
+
+  // Build child args (pure + testable — see buildDaemonArgs).
+  const args = buildDaemonArgs(opts, absDir, initialUrl, join(import.meta.dirname, '..', 'cli.js'));
 
   const child = spawn(process.execPath, args, {
     detached: true,

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -117,6 +117,9 @@ export async function runDaemon(opts, outputDir, initialUrl) {
     blockUrls: opts.blockUrls,
     blockPrivateNetwork: opts.blockPrivateNetwork,
     uploadDir: opts.uploadDir,
+    // incognito neuters injectCookies() session-wide; cookies:false (below)
+    // is the legacy per-open equivalent. Either yields a logged-out session.
+    incognito: opts.incognito || opts.cookies === false,
   });
 
   // Console + network log capture is CDP-specific (page.cdp). The Firefox/BiDi

--- a/src/firefox-page.js
+++ b/src/firefox-page.js
@@ -36,12 +36,15 @@ const BIDI_KEYS = {
  * @param {object} [opts]
  * @param {'act'|'browse'|'navigate'|'full'|'read'} [opts.pruneMode='act'] - Default prune mode.
  * @param {{allowLocalUrls?: boolean, blockPrivateNetwork?: boolean}} [opts.urlGuard] - Navigation safety policy, applied on every goto().
+ * @param {string} [opts.uploadDir] - When set, upload() rejects files outside this dir.
+ * @param {boolean} [opts.incognito=false] - Clean session: injectCookies() is a no-op.
  * @returns {Promise<object>} page object
  */
 export async function createFirefoxPage(bidi, opts = {}) {
   const defaultPruneMode = opts.pruneMode || 'act';
   const urlGuard = opts.urlGuard || {};
   const uploadDir = opts.uploadDir || null;
+  const incognito = !!opts.incognito;
   // The active browsing context. Starts at the initial tab; switchTab() points
   // it at another top-level context, so it's mutable and read via a getter.
   const { contexts } = await bidi.send('browsingContext.getTree', {});
@@ -214,6 +217,7 @@ export async function createFirefoxPage(bidi, opts = {}) {
      * via BiDi storage.setCookie. Same-engine reuse: Firefox cookies → Firefox.
      */
     async injectCookies(url, cookieOpts) {
+      if (incognito) return 0;
       const cookies = extractCookies({ browser: cookieOpts?.browser, domain: cookieOpts?.domain });
       for (const c of cookies) {
         const cookie = {

--- a/src/firefox-page.js
+++ b/src/firefox-page.js
@@ -19,7 +19,7 @@ import { formatTree } from './aria.js';
 import { prune as pruneTree } from './prune.js';
 import { axSnapshotExpression, REF_ATTR } from './ax-snapshot.js';
 import { EXTRACT_EXPRESSION, finalizeReadable } from './readable.js';
-import { extractCookies } from './auth.js';
+import { scopedCookiesForUrl } from './auth.js';
 import { assertNavigable, assertUploadAllowed } from './url-guard.js';
 
 /** BiDi/WebDriver normalized key values for named keys (U+E000 block). */
@@ -54,9 +54,16 @@ export async function createFirefoxPage(bidi, opts = {}) {
   // click after a snapshot routes to the frame the element actually lives in.
   let refContexts = new Map();
 
-  /** Depth-first list of every browsing context (main + descendant frames). */
+  /**
+   * Depth-first list of the ACTIVE tab's contexts (main frame + descendant
+   * frames). Scoped to `topContext` via getTree's `root` param — without it
+   * getTree returns every open tab flat, and after switchTab() to a non-first
+   * tab the positional iframe-splice in snapshot() grafts another tab's frame
+   * into the active tab (verified: INNER1 leaked into TAB2). Root-scoping keeps
+   * topContext at index 0 so the splice stays aligned and cross-tab-safe.
+   */
   async function allContexts() {
-    const { contexts: tree } = await bidi.send('browsingContext.getTree', {});
+    const { contexts: tree } = await bidi.send('browsingContext.getTree', { root: topContext });
     const flat = [];
     (function walk(nodes) {
       for (const n of nodes) { flat.push(n.context); walk(n.children || []); }
@@ -214,11 +221,13 @@ export async function createFirefoxPage(bidi, opts = {}) {
 
     /**
      * Inject cookies from the user's real browser into this Firefox session,
-     * via BiDi storage.setCookie. Same-engine reuse: Firefox cookies → Firefox.
+     * via BiDi storage.setCookie. Scoped to the URL host via the SHARED
+     * scopedCookiesForUrl (same as the CDP path) — never the whole jar.
      */
     async injectCookies(url, cookieOpts) {
       if (incognito) return 0;
-      const cookies = extractCookies({ browser: cookieOpts?.browser, domain: cookieOpts?.domain });
+      const cookies = scopedCookiesForUrl(url, { browser: cookieOpts?.browser });
+      let injected = 0;
       for (const c of cookies) {
         const cookie = {
           name: c.name,
@@ -230,8 +239,9 @@ export async function createFirefoxPage(bidi, opts = {}) {
         if (c.httpOnly) cookie.httpOnly = true;
         if (c.sameSite) cookie.sameSite = String(c.sameSite).toLowerCase();
         if (c.expires && c.expires > 0) cookie.expiry = Math.floor(c.expires);
-        try { await bidi.send('storage.setCookie', { cookie }); } catch { /* skip bad cookie */ }
+        try { await bidi.send('storage.setCookie', { cookie }); injected++; } catch { /* skip bad cookie */ }
       }
+      return injected;
     },
 
     async select(ref, value) {
@@ -352,6 +362,24 @@ export async function createFirefoxPage(bidi, opts = {}) {
         await new Promise((r) => setTimeout(r, 200));
       }
       throw new Error(`waitFor timed out after ${timeout}ms`);
+    },
+
+    // --- CDP-only surfaces, stubbed for daemon parity ---------------------
+    // The daemon (src/daemon.js) dispatches these unconditionally. On the
+    // Firefox/BiDi engine download tracking and dialog capture aren't wired,
+    // so the two logs are genuinely empty; the three actions are CDP-only and
+    // fail with a clear, intentional message instead of an incidental
+    // TypeError. Documented as a known gap in CHANGELOG (Firefox engine).
+    get downloads() { return []; },
+    get dialogLog() { return []; },
+    async saveState() {
+      throw new Error('saveState() is not supported on the Firefox/BiDi engine (CDP-only)');
+    },
+    async waitForNavigation() {
+      throw new Error('waitForNavigation() is not supported on the Firefox/BiDi engine (CDP-only)');
+    },
+    async waitForNetworkIdle() {
+      throw new Error('waitForNetworkIdle() is not supported on the Firefox/BiDi engine (CDP-only)');
     },
 
     async close() {

--- a/src/firefox-page.js
+++ b/src/firefox-page.js
@@ -1,0 +1,367 @@
+/**
+ * firefox-page.js — A barebrowse page object backed by WebDriver BiDi (Firefox).
+ *
+ * Mirrors the core of connect()'s CDP page surface — goto, snapshot, click,
+ * type, press, scroll, hover, readable, injectCookies, close — but every
+ * operation goes over BiDi instead of CDP. The tree that snapshot() feeds to
+ * prune.js/aria.js is reconstructed in-page by ax-snapshot.js (BiDi has no
+ * getFullAXTree), and refs resolve to elements through the data-bb-ref
+ * attribute those snapshots stamp on.
+ *
+ * Interactions use faithful BiDi input.performActions with an *element origin*
+ * (pointerMove auto-scrolls the element into view, then real pointerDown/Up
+ * fire) rather than a synthetic el.click(), so pages that need genuine mouse
+ * events behave. Refs are resolved to BiDi element sharedIds per context, so
+ * clicks land in the right frame.
+ */
+
+import { formatTree } from './aria.js';
+import { prune as pruneTree } from './prune.js';
+import { axSnapshotExpression, REF_ATTR } from './ax-snapshot.js';
+import { EXTRACT_EXPRESSION, finalizeReadable } from './readable.js';
+import { extractCookies } from './auth.js';
+import { assertNavigable, assertUploadAllowed } from './url-guard.js';
+
+/** BiDi/WebDriver normalized key values for named keys (U+E000 block). */
+const BIDI_KEYS = {
+  Enter: "\uE007", Tab: "\uE004", Escape: "\uE00C", Backspace: "\uE003",
+  Delete: "\uE017", ArrowUp: "\uE013", ArrowDown: "\uE015",
+  ArrowLeft: "\uE012", ArrowRight: "\uE014", Home: "\uE011", End: "\uE010",
+  PageUp: "\uE00E", PageDown: "\uE00F", Space: " ",
+};
+
+/**
+ * Build a Firefox/BiDi-backed page object.
+ * @param {object} bidi - BiDi client from createBiDi()
+ * @param {object} [opts]
+ * @param {'act'|'browse'|'navigate'|'full'|'read'} [opts.pruneMode='act'] - Default prune mode.
+ * @param {{allowLocalUrls?: boolean, blockPrivateNetwork?: boolean}} [opts.urlGuard] - Navigation safety policy, applied on every goto().
+ * @returns {Promise<object>} page object
+ */
+export async function createFirefoxPage(bidi, opts = {}) {
+  const defaultPruneMode = opts.pruneMode || 'act';
+  const urlGuard = opts.urlGuard || {};
+  const uploadDir = opts.uploadDir || null;
+  // The active browsing context. Starts at the initial tab; switchTab() points
+  // it at another top-level context, so it's mutable and read via a getter.
+  const { contexts } = await bidi.send('browsingContext.getTree', {});
+  let topContext = contexts[0].context;
+
+  // ref (string int) → owning browsing-context id, rebuilt every snapshot so a
+  // click after a snapshot routes to the frame the element actually lives in.
+  let refContexts = new Map();
+
+  /** Depth-first list of every browsing context (main + descendant frames). */
+  async function allContexts() {
+    const { contexts: tree } = await bidi.send('browsingContext.getTree', {});
+    const flat = [];
+    (function walk(nodes) {
+      for (const n of nodes) { flat.push(n.context); walk(n.children || []); }
+    })(tree);
+    return flat;
+  }
+
+  /** Resolve a ref to a BiDi element sharedId in its owning context. */
+  async function resolveRef(ref) {
+    const context = refContexts.get(String(ref));
+    if (!context) throw new Error(`Unknown ref: ${ref} (snapshot first, or it's stale)`);
+    const res = await bidi.send('script.evaluate', {
+      expression: `document.querySelector('[${REF_ATTR}="${ref}"]')`,
+      target: { context }, awaitPromise: false, resultOwnership: 'root',
+    });
+    if (res.type === 'exception' || !res.result || res.result.type !== 'node') {
+      throw new Error(`Could not resolve element for ref ${ref}`);
+    }
+    return { context, sharedId: res.result.sharedId };
+  }
+
+  async function pointerClick(ref) {
+    const { context, sharedId } = await resolveRef(ref);
+    await bidi.send('input.performActions', {
+      context,
+      actions: [{
+        type: 'pointer', id: 'mouse', parameters: { pointerType: 'mouse' },
+        actions: [
+          { type: 'pointerMove', x: 0, y: 0, origin: { type: 'element', element: { sharedId } } },
+          { type: 'pointerDown', button: 0 },
+          { type: 'pointerUp', button: 0 },
+        ],
+      }],
+    });
+  }
+
+  async function keyType(context, text) {
+    const actions = [];
+    for (const ch of text) { actions.push({ type: 'keyDown', value: ch }, { type: 'keyUp', value: ch }); }
+    await bidi.send('input.performActions', {
+      context, actions: [{ type: 'key', id: 'kbd', actions }],
+    });
+  }
+
+  const page = {
+    /** The BiDi escape hatch, analogous to connect()'s page.cdp. */
+    get bidi() { return bidi; },
+    /** The active browsing-context id (getter so it tracks switchTab). */
+    get context() { return topContext; },
+
+    async goto(url, timeout = 30000) {
+      // Same navigation guard the CDP path enforces — block file:/chrome:/
+      // view-source: and (optionally) private-network hosts before navigating.
+      assertNavigable(url, urlGuard);
+      await bidi.send('browsingContext.navigate', { context: topContext, url, wait: 'complete' });
+      // Brief settle for dynamic/SPA content, matching the CDP path.
+      await new Promise((r) => setTimeout(r, 500));
+    },
+
+    async snapshot(pruneOpts) {
+      const contextIds = await allContexts();
+      refContexts = new Map();
+
+      // Snapshot each context, assigning refs from a shared running counter so
+      // they're globally unique (matching CDP's flat integer refs).
+      let base = 0;
+      const treesByContext = new Map();
+      for (const ctx of contextIds) {
+        let raw;
+        try {
+          raw = await bidi.evaluate(ctx, axSnapshotExpression(base), false);
+        } catch { continue; } // frame navigated mid-snapshot — skip it
+        const { tree, count } = JSON.parse(raw);
+        for (let r = base + 1; r <= base + count; r++) refContexts.set(String(r), ctx);
+        base += count;
+        treesByContext.set(ctx, tree);
+      }
+
+      // Splice each child frame's tree under an <iframe> (role 'Iframe')
+      // placeholder in its parent, matched by document order — BiDi getTree
+      // lists children in frame order, and the AX walk emits Iframe nodes in
+      // the same order.
+      const iframeNodes = (tree) => {
+        const out = [];
+        (function walk(n) { if (n.role === 'Iframe') out.push(n); for (const c of n.children) walk(c); })(tree);
+        return out;
+      };
+      for (let i = 1; i < contextIds.length; i++) {
+        const childTree = treesByContext.get(contextIds[i]);
+        if (!childTree) continue;
+        // Attach to the next unfilled Iframe placeholder in the top tree.
+        const holders = iframeNodes(treesByContext.get(topContext) || { role: '', children: [] });
+        const holder = holders[i - 1];
+        if (holder) holder.children = [childTree];
+      }
+
+      const root = treesByContext.get(topContext);
+      if (!root) return '';
+
+      const pageUrl = await bidi.evaluate(topContext, 'location.href', false).catch(() => '');
+      const raw = formatTree(root);
+      if (pruneOpts === false) return `url: ${pageUrl}\n` + raw;
+
+      const mode = pruneOpts?.mode || defaultPruneMode;
+      const pruned = pruneTree(root, { mode });
+      const out = pruned ? formatTree(pruned) : '';
+      const stats = `url: ${pageUrl}\n${raw.length.toLocaleString()} chars → ${out.length.toLocaleString()} chars`
+        + ` (${raw.length ? Math.round((1 - out.length / raw.length) * 100) : 0}% pruned)`;
+      return stats + '\n' + out;
+    },
+
+    async readable() {
+      const raw = await bidi.evaluate(topContext, `JSON.stringify(${EXTRACT_EXPRESSION})`, true);
+      return finalizeReadable(JSON.parse(raw));
+    },
+
+    async click(ref) { await pointerClick(ref); },
+
+    async type(ref, text, typeOpts = {}) {
+      const { context, sharedId } = await resolveRef(ref);
+      // Focus the field (and optionally clear it) in-page, then send real key
+      // events so input handlers fire.
+      await bidi.send('script.callFunction', {
+        functionDeclaration: `function(clear){ this.focus(); if(clear){ if('value' in this) this.value=''; else this.textContent=''; this.dispatchEvent(new Event('input',{bubbles:true})); } }`,
+        arguments: [{ type: 'boolean', value: !!typeOpts.clear }],
+        this: { sharedId },
+        target: { context }, awaitPromise: false,
+      });
+      await keyType(context, text);
+    },
+
+    async press(key) {
+      const value = BIDI_KEYS[key] || (key.length === 1 ? key : null);
+      if (!value) throw new Error(`Unknown key: "${key}". Valid: ${Object.keys(BIDI_KEYS).join(', ')}`);
+      await bidi.send('input.performActions', {
+        context: topContext,
+        actions: [{ type: 'key', id: 'kbd', actions: [{ type: 'keyDown', value }, { type: 'keyUp', value }] }],
+      });
+    },
+
+    async scroll(deltaY) {
+      await bidi.evaluate(topContext, `window.scrollBy(0, ${Number(deltaY)})`, false);
+    },
+
+    async hover(ref) {
+      const { context, sharedId } = await resolveRef(ref);
+      await bidi.send('input.performActions', {
+        context,
+        actions: [{
+          type: 'pointer', id: 'mouse', parameters: { pointerType: 'mouse' },
+          actions: [{ type: 'pointerMove', x: 0, y: 0, origin: { type: 'element', element: { sharedId } } }],
+        }],
+      });
+    },
+
+    /**
+     * Inject cookies from the user's real browser into this Firefox session,
+     * via BiDi storage.setCookie. Same-engine reuse: Firefox cookies → Firefox.
+     */
+    async injectCookies(url, cookieOpts) {
+      const cookies = extractCookies({ browser: cookieOpts?.browser, domain: cookieOpts?.domain });
+      for (const c of cookies) {
+        const cookie = {
+          name: c.name,
+          value: { type: 'string', value: String(c.value ?? '') },
+          domain: String(c.domain || '').replace(/^\./, ''),
+          path: c.path || '/',
+        };
+        if (c.secure) cookie.secure = true;
+        if (c.httpOnly) cookie.httpOnly = true;
+        if (c.sameSite) cookie.sameSite = String(c.sameSite).toLowerCase();
+        if (c.expires && c.expires > 0) cookie.expiry = Math.floor(c.expires);
+        try { await bidi.send('storage.setCookie', { cookie }); } catch { /* skip bad cookie */ }
+      }
+    },
+
+    async select(ref, value) {
+      const { context, sharedId } = await resolveRef(ref);
+      // Native <select>: set value + fire change. Custom dropdown: open then
+      // click the matching option. Mirrors interact.js's two strategies.
+      const handled = await bidi.send('script.callFunction', {
+        functionDeclaration: `function(v){
+          if (this.tagName === 'SELECT') {
+            const opt = Array.from(this.options).find(o => o.value === v || o.textContent.trim() === v);
+            if (opt) { this.value = opt.value; this.dispatchEvent(new Event('change',{bubbles:true})); return true; }
+            return false;
+          }
+          this.click();
+          return false;
+        }`,
+        arguments: [{ type: 'string', value }],
+        this: { sharedId }, target: { context }, awaitPromise: false,
+      });
+      if (handled.type === 'success' && handled.result?.value === true) return;
+      // Custom dropdown fallback: click a matching option after it opens.
+      await new Promise((r) => setTimeout(r, 300));
+      await bidi.evaluate(context, `(() => {
+        for (const o of document.querySelectorAll('[role="option"],[role="menuitem"],li[role="option"]')) {
+          if (o.textContent.trim() === ${JSON.stringify(value)}) { o.click(); return true; }
+        }
+        return false;
+      })()`, false);
+    },
+
+    async drag(fromRef, toRef) {
+      const from = await resolveRef(fromRef);
+      const to = await resolveRef(toRef);
+      if (from.context !== to.context) {
+        throw new Error('drag() between elements in different frames is not supported');
+      }
+      await bidi.send('input.performActions', {
+        context: from.context,
+        actions: [{
+          type: 'pointer', id: 'mouse', parameters: { pointerType: 'mouse' },
+          actions: [
+            { type: 'pointerMove', x: 0, y: 0, origin: { type: 'element', element: { sharedId: from.sharedId } } },
+            { type: 'pointerDown', button: 0 },
+            { type: 'pointerMove', x: 0, y: 0, origin: { type: 'element', element: { sharedId: to.sharedId } } },
+            { type: 'pointerUp', button: 0 },
+          ],
+        }],
+      });
+    },
+
+    async upload(ref, files) {
+      // Same upload sandbox the CDP path enforces: every path must resolve
+      // (symlinks included) inside uploadDir when set.
+      assertUploadAllowed(files, uploadDir);
+      const { context, sharedId } = await resolveRef(ref);
+      await bidi.send('input.setFiles', { context, element: { sharedId }, files });
+    },
+
+    async goBack() { await traverse(-1); },
+    async goForward() { await traverse(1); },
+
+    async reload() {
+      // Note: Firefox BiDi does not yet support the ignoreCache argument, so
+      // (unlike the CDP path) reload() always does a normal reload.
+      await bidi.send('browsingContext.reload', { context: topContext, wait: 'complete' });
+      refContexts = new Map();
+      await new Promise((r) => setTimeout(r, 300));
+    },
+
+    async screenshot(screenshotOpts = {}) {
+      const fmt = screenshotOpts.format || 'png';
+      const type = fmt === 'jpeg' ? 'image/jpeg' : fmt === 'webp' ? 'image/webp' : 'image/png';
+      const format = { type };
+      if (type !== 'image/png') format.quality = (screenshotOpts.quality || 80) / 100;
+      const { data } = await bidi.send('browsingContext.captureScreenshot', { context: topContext, format });
+      return data; // base64
+    },
+
+    async pdf(pdfOpts = {}) {
+      const { data } = await bidi.send('browsingContext.print', {
+        context: topContext,
+        background: true,
+        orientation: pdfOpts.landscape ? 'landscape' : 'portrait',
+      });
+      return data; // base64
+    },
+
+    async tabs() {
+      const { contexts: tree } = await bidi.send('browsingContext.getTree', {});
+      const out = [];
+      for (let i = 0; i < tree.length; i++) {
+        const title = await bidi.evaluate(tree[i].context, 'document.title', false).catch(() => '');
+        out.push({ index: i, url: tree[i].url, title, context: tree[i].context });
+      }
+      return out;
+    },
+
+    async switchTab(index) {
+      const { contexts: tree } = await bidi.send('browsingContext.getTree', {});
+      if (index < 0 || index >= tree.length) throw new Error(`Tab index ${index} out of range (0-${tree.length - 1})`);
+      topContext = tree[index].context;
+      refContexts = new Map(); // refs from the previous tab are invalid
+      await bidi.send('browsingContext.activate', { context: topContext }).catch(() => {});
+    },
+
+    async waitFor(waitOpts = {}) {
+      const timeout = waitOpts.timeout || 30000;
+      const deadline = Date.now() + timeout;
+      while (Date.now() < deadline) {
+        if (waitOpts.text) {
+          const t = await bidi.evaluate(topContext, 'document.body ? document.body.innerText : ""', false).catch(() => '');
+          if (t && t.includes(waitOpts.text)) return;
+        }
+        if (waitOpts.selector) {
+          const found = await bidi.evaluate(topContext, `!!document.querySelector(${JSON.stringify(waitOpts.selector)})`, false).catch(() => false);
+          if (found) return;
+        }
+        await new Promise((r) => setTimeout(r, 200));
+      }
+      throw new Error(`waitFor timed out after ${timeout}ms`);
+    },
+
+    async close() {
+      try { await bidi.send('browsingContext.close', { context: topContext }); } catch {}
+      bidi.close();
+    },
+  };
+
+  /** Walk session history by delta and settle (BiDi has no load-wait here). */
+  async function traverse(delta) {
+    await bidi.send('browsingContext.traverseHistory', { context: topContext, delta });
+    refContexts = new Map();
+    await new Promise((r) => setTimeout(r, 500));
+  }
+
+  return page;
+}

--- a/src/firefox-page.js
+++ b/src/firefox-page.js
@@ -108,6 +108,17 @@ export async function createFirefoxPage(bidi, opts = {}) {
     });
   }
 
+  /**
+   * Reject if `p` doesn't settle within `ms`. BiDi commands have no built-in
+   * timeout, so a navigate/reload/traverse whose `wait:'complete'` never fires
+   * (a page that never loads) would otherwise hang the call forever.
+   */
+  function withTimeout(p, ms, label) {
+    let timer;
+    const t = new Promise((_, rej) => { timer = setTimeout(() => rej(new Error(`${label} timed out after ${ms}ms`)), ms); });
+    return Promise.race([p, t]).finally(() => clearTimeout(timer));
+  }
+
   const page = {
     /** The BiDi escape hatch, analogous to connect()'s page.cdp. */
     get bidi() { return bidi; },
@@ -118,7 +129,9 @@ export async function createFirefoxPage(bidi, opts = {}) {
       // Same navigation guard the CDP path enforces — block file:/chrome:/
       // view-source: and (optionally) private-network hosts before navigating.
       assertNavigable(url, urlGuard);
-      await bidi.send('browsingContext.navigate', { context: topContext, url, wait: 'complete' });
+      await withTimeout(
+        bidi.send('browsingContext.navigate', { context: topContext, url, wait: 'complete' }),
+        timeout, `goto(${url})`);
       // Brief settle for dynamic/SPA content, matching the CDP path.
       await new Promise((r) => setTimeout(r, 500));
     },
@@ -306,7 +319,9 @@ export async function createFirefoxPage(bidi, opts = {}) {
     async reload() {
       // Note: Firefox BiDi does not yet support the ignoreCache argument, so
       // (unlike the CDP path) reload() always does a normal reload.
-      await bidi.send('browsingContext.reload', { context: topContext, wait: 'complete' });
+      await withTimeout(
+        bidi.send('browsingContext.reload', { context: topContext, wait: 'complete' }),
+        30000, 'reload');
       refContexts = new Map();
       await new Promise((r) => setTimeout(r, 300));
     },
@@ -390,7 +405,9 @@ export async function createFirefoxPage(bidi, opts = {}) {
 
   /** Walk session history by delta and settle (BiDi has no load-wait here). */
   async function traverse(delta) {
-    await bidi.send('browsingContext.traverseHistory', { context: topContext, delta });
+    await withTimeout(
+      bidi.send('browsingContext.traverseHistory', { context: topContext, delta }),
+      30000, 'history navigation');
     refContexts = new Map();
     await new Promise((r) => setTimeout(r, 500));
   }

--- a/src/firefox.js
+++ b/src/firefox.js
@@ -1,0 +1,188 @@
+/**
+ * firefox.js — Find and launch Firefox with WebDriver BiDi enabled.
+ *
+ * The BiDi counterpart to chromium.js. Firefox deprecated CDP, so it's driven
+ * over the W3C BiDi protocol instead. `--remote-debugging-port` starts
+ * Firefox's remote agent, which prints its BiDi endpoint to stderr:
+ *   "WebDriver BiDi listening on ws://127.0.0.1:PORT"
+ * The direct-connection socket (no geckodriver / WebDriver-classic handshake)
+ * is that URL + "/session" — createBiDi() appends it. No new dependency:
+ * BiDi rides the same `ws` transport as CDP.
+ *
+ * Like chromium.js we launch a fresh temp profile (never the user's live
+ * profile — that would profile-lock their running Firefox) and reap the
+ * process + profile dir on parent crash.
+ */
+
+import { execFileSync, spawn } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/** Block the current thread for `ms` (sync, for the 'exit' reaper). */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+// Reap launched Firefoxes on parent crash — mirrors chromium.js.
+const activeBrowsers = new Set();
+let exitHandlersRegistered = false;
+
+function reapAllSync() {
+  const toReap = [...activeBrowsers];
+  activeBrowsers.clear();
+  for (const b of toReap) {
+    try { if (!b.process.killed) b.process.kill('SIGKILL'); } catch {}
+    try { process.kill(-b.process.pid, 'SIGKILL'); } catch {}
+  }
+  for (const b of toReap) {
+    for (let i = 0; i < 20; i++) {
+      try { process.kill(b.process.pid, 0); } catch { break; }
+      sleepSync(50);
+    }
+    if (b.ownedProfileDir) {
+      try { rmSync(b.ownedProfileDir, { recursive: true, force: true }); } catch {}
+    }
+  }
+}
+
+function registerExitHandlers() {
+  if (exitHandlersRegistered) return;
+  exitHandlersRegistered = true;
+  process.once('exit', reapAllSync);
+  for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+    process.once(sig, () => { reapAllSync(); process.kill(process.pid, sig); });
+  }
+}
+
+const CANDIDATES = [
+  'firefox',
+  'firefox-esr',
+  'firefox-developer-edition',
+  'librewolf',
+  '/Applications/Firefox.app/Contents/MacOS/firefox',
+];
+
+/**
+ * Find the first available Firefox binary on the system.
+ * @returns {string} Path to the binary
+ * @throws {Error} If no Firefox is found
+ */
+export function findFirefox() {
+  for (const candidate of CANDIDATES) {
+    try {
+      if (candidate.startsWith('/')) {
+        execFileSync('test', ['-f', candidate]);
+        return candidate;
+      }
+      const path = execFileSync('which', [candidate], {
+        encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+      if (path) return path;
+    } catch { /* try next */ }
+  }
+  throw new Error(
+    'No Firefox binary found. Install Firefox (>= 121 for stable BiDi).\n' +
+    'On Fedora: sudo dnf install firefox'
+  );
+}
+
+/**
+ * Launch Firefox with WebDriver BiDi enabled and return its session WS URL.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.binary] - Firefox binary (auto-detected if omitted)
+ * @param {number} [opts.port=0] - Remote-agent port (0 = OS-assigned)
+ * @param {boolean} [opts.headed=false] - Launch with a visible window
+ * @param {string} [opts.proxy] - Proxy 'host:port' (applied via profile prefs)
+ * @param {{width:number,height:number}} [opts.viewport] - Initial window size
+ * @returns {Promise<{wsUrl: string, process: import('node:child_process').ChildProcess, port: number, ownedProfileDir: string}>}
+ */
+export async function launchFirefox(opts = {}) {
+  const binary = opts.binary || findFirefox();
+  const port = opts.port || 0;
+  const profileDir = mkdtempSync(join(tmpdir(), 'barebrowse-ff-'));
+
+  // Proxy + prompt-suppressing prefs go in user.js (read at profile load).
+  const prefs = [
+    'user_pref("browser.shell.checkDefaultBrowser", false);',
+    'user_pref("datareporting.policy.dataSubmissionEnabled", false);',
+    'user_pref("dom.webnotifications.enabled", false);',
+    'user_pref("permissions.default.desktop-notification", 1);',
+    'user_pref("media.navigator.permission.disabled", true);',
+    'user_pref("geo.prompt.testing", true);',
+    'user_pref("geo.prompt.testing.allow", true);',
+  ];
+  if (opts.proxy) {
+    // opts.proxy is 'host:port' (optionally with scheme). Strip any scheme.
+    const hostPort = String(opts.proxy).replace(/^\w+:\/\//, '');
+    const [host, pport] = hostPort.split(':');
+    prefs.push(
+      'user_pref("network.proxy.type", 1);',
+      `user_pref("network.proxy.http", "${host}");`,
+      `user_pref("network.proxy.http_port", ${Number(pport) || 8080});`,
+      `user_pref("network.proxy.ssl", "${host}");`,
+      `user_pref("network.proxy.ssl_port", ${Number(pport) || 8080});`,
+      'user_pref("network.proxy.share_proxy_settings", true);',
+    );
+  }
+  writeFileSync(join(profileDir, 'user.js'), prefs.join('\n'));
+
+  const args = [
+    '--remote-debugging-port', String(port),
+    '--no-remote', '--new-instance',
+    '--profile', profileDir,
+  ];
+  if (!opts.headed) args.push('--headless');
+  if (opts.viewport) args.push('--width', String(opts.viewport.width), '--height', String(opts.viewport.height));
+  args.push('about:blank');
+
+  // detached:true → own process group, so cleanup can signal the whole tree.
+  const child = spawn(binary, args, { stdio: ['ignore', 'pipe', 'pipe'], detached: true });
+
+  // Firefox prints the BiDi endpoint to stderr. Wait for it (or die trying).
+  const wsUrl = await new Promise((resolve, reject) => {
+    let buf = '';
+    const timeout = setTimeout(() => reject(new Error(`Firefox BiDi did not start within 20s. stderr: ${buf}`)), 20000);
+    const scan = (chunk) => {
+      buf += chunk.toString();
+      const m = buf.match(/WebDriver BiDi listening on (ws:\/\/\S+)/);
+      if (m) { clearTimeout(timeout); resolve(m[1].replace(/\/?$/, '') + '/session'); }
+    };
+    child.stderr.on('data', scan);
+    child.stdout.on('data', scan);
+    child.on('error', (err) => { clearTimeout(timeout); reject(new Error(`Failed to launch Firefox: ${err.message}`)); });
+    child.on('exit', (code) => {
+      clearTimeout(timeout);
+      if (!buf.includes('WebDriver BiDi')) reject(new Error(`Firefox exited with code ${code}. stderr: ${buf}`));
+    });
+  });
+
+  const actualPort = parseInt(new URL(wsUrl.replace('/session', '')).port, 10);
+  const browser = { wsUrl, process: child, port: actualPort, ownedProfileDir: profileDir };
+
+  registerExitHandlers();
+  activeBrowsers.add(browser);
+  child.once('exit', () => activeBrowsers.delete(browser));
+
+  return browser;
+}
+
+/**
+ * Kill a launched Firefox and remove its temp profile dir.
+ * @param {{process: import('node:child_process').ChildProcess, ownedProfileDir?: string}} browser
+ */
+export async function cleanupFirefox(browser) {
+  if (!browser) return;
+  activeBrowsers.delete(browser);
+  try { if (!browser.process.killed) browser.process.kill('SIGKILL'); } catch {}
+  try { process.kill(-browser.process.pid, 'SIGKILL'); } catch {}
+  // Wait for death so rmSync doesn't race Firefox's profile file handles.
+  for (let i = 0; i < 40; i++) {
+    try { process.kill(browser.process.pid, 0); } catch { break; }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  if (browser.ownedProfileDir) {
+    try { rmSync(browser.ownedProfileDir, { recursive: true, force: true }); } catch {}
+  }
+}

--- a/src/firefox.js
+++ b/src/firefox.js
@@ -175,11 +175,12 @@ export async function launchFirefox(opts = {}) {
 export async function cleanupFirefox(browser) {
   if (!browser) return;
   activeBrowsers.delete(browser);
+  const pid = browser.process.pid;
   try { if (!browser.process.killed) browser.process.kill('SIGKILL'); } catch {}
-  try { process.kill(-browser.process.pid, 'SIGKILL'); } catch {}
+  if (pid != null) try { process.kill(-pid, 'SIGKILL'); } catch {}
   // Wait for death so rmSync doesn't race Firefox's profile file handles.
-  for (let i = 0; i < 40; i++) {
-    try { process.kill(browser.process.pid, 0); } catch { break; }
+  for (let i = 0; pid != null && i < 40; i++) {
+    try { process.kill(pid, 0); } catch { break; }
     await new Promise((r) => setTimeout(r, 50));
   }
   if (browser.ownedProfileDir) {

--- a/src/firefox.js
+++ b/src/firefox.js
@@ -94,7 +94,8 @@ export function findFirefox() {
  * @param {string} [opts.binary] - Firefox binary (auto-detected if omitted)
  * @param {number} [opts.port=0] - Remote-agent port (0 = OS-assigned)
  * @param {boolean} [opts.headed=false] - Launch with a visible window
- * @param {string} [opts.proxy] - Proxy 'host:port' (applied via profile prefs)
+ * @param {string} [opts.proxy] - Proxy 'host:port' or 'scheme://host:port'
+ *   (http/https → HTTP+SSL proxy; socks/socks5/socks4 → SOCKS), via prefs
  * @param {{width:number,height:number}} [opts.viewport] - Initial window size
  * @returns {Promise<{wsUrl: string, process: import('node:child_process').ChildProcess, port: number, ownedProfileDir: string}>}
  */
@@ -114,17 +115,30 @@ export async function launchFirefox(opts = {}) {
     'user_pref("geo.prompt.testing.allow", true);',
   ];
   if (opts.proxy) {
-    // opts.proxy is 'host:port' (optionally with scheme). Strip any scheme.
-    const hostPort = String(opts.proxy).replace(/^\w+:\/\//, '');
-    const [host, pport] = hostPort.split(':');
-    prefs.push(
-      'user_pref("network.proxy.type", 1);',
-      `user_pref("network.proxy.http", "${host}");`,
-      `user_pref("network.proxy.http_port", ${Number(pport) || 8080});`,
-      `user_pref("network.proxy.ssl", "${host}");`,
-      `user_pref("network.proxy.ssl_port", ${Number(pport) || 8080});`,
-      'user_pref("network.proxy.share_proxy_settings", true);',
-    );
+    // Honor the scheme: a socks:// proxy must be wired as SOCKS, not HTTP —
+    // otherwise SOCKS traffic is silently sent to an HTTP proxy and fails.
+    const raw = String(opts.proxy);
+    const scheme = (raw.match(/^(\w+):\/\//)?.[1] || '').toLowerCase();
+    const [host, pport] = raw.replace(/^\w+:\/\//, '').split(':');
+    const isSocks = scheme.startsWith('socks');
+    const port = Number(pport) || (isSocks ? 1080 : 8080);
+    prefs.push('user_pref("network.proxy.type", 1);');
+    if (isSocks) {
+      prefs.push(
+        `user_pref("network.proxy.socks", "${host}");`,
+        `user_pref("network.proxy.socks_port", ${port});`,
+        `user_pref("network.proxy.socks_version", ${scheme === 'socks4' ? 4 : 5});`,
+        'user_pref("network.proxy.socks_remote_dns", true);',
+      );
+    } else {
+      prefs.push(
+        `user_pref("network.proxy.http", "${host}");`,
+        `user_pref("network.proxy.http_port", ${port});`,
+        `user_pref("network.proxy.ssl", "${host}");`,
+        `user_pref("network.proxy.ssl_port", ${port});`,
+        'user_pref("network.proxy.share_proxy_settings", true);',
+      );
+    }
   }
   writeFileSync(join(profileDir, 'user.js'), prefs.join('\n'));
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,10 @@
  */
 
 import { launch, attach, cleanupBrowser } from './chromium.js';
+import { launchFirefox, cleanupFirefox } from './firefox.js';
 import { createCDP } from './cdp.js';
+import { createBiDi } from './bidi.js';
+import { createFirefoxPage } from './firefox-page.js';
 import { formatTree } from './aria.js';
 import { authenticate } from './auth.js';
 import { prune as pruneTree } from './prune.js';
@@ -192,6 +195,13 @@ export async function browse(url, opts = {}) {
  * @returns {Promise<object>} Page handle with goto, snapshot, close
  */
 export async function connect(opts = {}) {
+  // Firefox is driven over WebDriver BiDi (CDP is deprecated there) — a
+  // separate transport with its own page object. It reuses prune.js/aria.js/
+  // readable.js but none of the CDP page machinery below, so branch early.
+  if (opts.engine === 'firefox') {
+    return connectFirefox(opts);
+  }
+
   const mode = opts.mode || 'headless';
   const attachMode = !!opts.port;
   let browser = null;
@@ -706,6 +716,35 @@ async function suppressPermissions(cdp) {
       // Permission type not supported in this Chrome version — skip
     }
   }
+}
+
+/**
+ * Firefox path for connect(): launch Firefox, open a BiDi session, and return
+ * a BiDi-backed page object. Separate from the CDP path because the transport,
+ * ref model, and AX-tree source all differ (see firefox-page.js). close() is
+ * wrapped to also reap the Firefox process + temp profile.
+ * @param {object} opts - connect() options ({ mode, proxy, binary, viewport, pruneMode })
+ * @returns {Promise<object>} Firefox page object
+ */
+async function connectFirefox(opts) {
+  const browser = await launchFirefox({
+    headed: opts.mode === 'headed',
+    proxy: opts.proxy,
+    binary: opts.binary,
+    viewport: opts.viewport,
+  });
+  const bidi = await createBiDi(browser.wsUrl);
+  const page = await createFirefoxPage(bidi, {
+    pruneMode: opts.pruneMode,
+    urlGuard: { allowLocalUrls: opts.allowLocalUrls, blockPrivateNetwork: opts.blockPrivateNetwork },
+    uploadDir: opts.uploadDir || null,
+  });
+  const closePage = page.close.bind(page);
+  page.close = async () => {
+    await closePage();
+    await cleanupFirefox(browser);
+  };
+  return page;
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -745,7 +745,14 @@ async function suppressPermissions(cdp) {
  * a BiDi-backed page object. Separate from the CDP path because the transport,
  * ref model, and AX-tree source all differ (see firefox-page.js). close() is
  * wrapped to also reap the Firefox process + temp profile.
- * @param {object} opts - connect() options ({ mode, proxy, binary, viewport, pruneMode })
+ *
+ * Chromium-only options NOT applied on this path: `consent` (auto-dismiss),
+ * `blockAds`/`blockUrls`, stealth patches, and `hybrid` mode. `saveState`,
+ * `waitForNavigation`, `waitForNetworkIdle`, and download/dialog capture are
+ * CDP-only too (the page object stubs them — see firefox-page.js). The
+ * navigation guard (`allowLocalUrls`/`blockPrivateNetwork`), `uploadDir`
+ * sandbox, `incognito`, `proxy`, `viewport`, and `pruneMode` DO apply.
+ * @param {object} opts - connect() options ({ mode, proxy, binary, viewport, pruneMode, urlGuard, uploadDir, incognito })
  * @returns {Promise<object>} Firefox page object
  */
 async function connectFirefox(opts) {

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,8 @@ import { chmodSync } from 'node:fs';
  * @param {object} [opts]
  * @param {'headless'|'headed'|'hybrid'} [opts.mode='headless'] - Browser mode
  * @param {boolean} [opts.cookies=true] - Inject user's cookies (Phase 2)
+ * @param {boolean} [opts.incognito=false] - Clean, unauthenticated session:
+ *   skip cookie/auth injection entirely (equivalent to cookies:false here).
  * @param {boolean} [opts.prune=true] - Apply ARIA pruning (Phase 2)
  * @param {number} [opts.timeout=30000] - Navigation timeout in ms
  * @param {boolean} [opts.blockAds=true] - Block ~120 common ad/tracker
@@ -57,6 +59,8 @@ import { chmodSync } from 'node:fs';
 export async function browse(url, opts = {}) {
   const mode = opts.mode || 'headless';
   const timeout = opts.timeout || 30000;
+  // Skip all auth injection when incognito (or the legacy cookies:false).
+  const noAuth = !!opts.incognito || opts.cookies === false;
 
   // Reject local-resource schemes (and optionally private hosts) before we
   // spend a browser launch on a URL we won't navigate to.
@@ -87,7 +91,7 @@ export async function browse(url, opts = {}) {
     await suppressPermissions(cdp);
 
     // Step 3: Cookie injection — extract from user's browser, inject via CDP
-    if (opts.cookies !== false) {
+    if (!noAuth) {
       try {
         await authenticate(page.session, url, { browser: opts.browser });
       } catch {
@@ -117,7 +121,7 @@ export async function browse(url, opts = {}) {
         cdp = await createCDP(browser.wsUrl);
         page = await createPage(cdp, false, pageOpts);
         await suppressPermissions(cdp);
-        if (opts.cookies !== false) {
+        if (!noAuth) {
           try { await authenticate(page.session, url, { browser: opts.browser }); } catch {}
         }
         await navigate(page, url, timeout);
@@ -191,7 +195,13 @@ export async function browse(url, opts = {}) {
  * @param {boolean} [opts.consent=true] - Auto-dismiss cookie consent dialogs.
  * @param {string} [opts.storageState] - Path to a storage-state JSON file
  *   (cookies + localStorage) to load before navigation.
+ * @param {boolean} [opts.incognito=false] - Clean, unauthenticated session:
+ *   skip storageState loading and make injectCookies() a no-op, so no auth
+ *   ever enters the session even if a caller injects unconditionally.
  * @param {'act'|'browse'|'navigate'|'full'|'read'} [opts.pruneMode='act'] - Pruning mode.
+ * @param {'chromium'|'firefox'} [opts.engine='chromium'] - Browser engine.
+ *   'firefox' drives over WebDriver BiDi (a separate transport / page object);
+ *   'chromium' (default) uses CDP.
  * @returns {Promise<object>} Page handle with goto, snapshot, close
  */
 export async function connect(opts = {}) {
@@ -204,6 +214,13 @@ export async function connect(opts = {}) {
 
   const mode = opts.mode || 'headless';
   const attachMode = !!opts.port;
+  // Incognito: run a clean, unauthenticated session. Skips storageState loading
+  // and neuters injectCookies() so no auth ever enters the session — even when
+  // a caller (MCP goto, daemon) calls injectCookies() unconditionally. The
+  // temp profile is already throwaway; this gates the OTHER auth source: the
+  // user's real browser cookies. Not Chrome's --incognito flag (redundant with
+  // the temp profile and would break the cookie-injection path when off).
+  const incognito = !!opts.incognito;
   let browser = null;
   let cdp;
   // Forward caller-supplied launch knobs into every launch() below,
@@ -253,8 +270,9 @@ export async function connect(opts = {}) {
     await suppressPermissions(cdp);
   }
 
-  // Load storage state (cookies + localStorage) from file
-  if (opts.storageState) {
+  // Load storage state (cookies + localStorage) from file.
+  // Skipped under incognito — storageState is an auth source too.
+  if (opts.storageState && !incognito) {
     try {
       const { readFileSync } = await import('node:fs');
       const state = JSON.parse(readFileSync(opts.storageState, 'utf8'));
@@ -449,7 +467,10 @@ export async function connect(opts = {}) {
     },
 
     async injectCookies(url, cookieOpts) {
-      await authenticate(page.session, url, { browser: cookieOpts?.browser });
+      // No-op under incognito: callers (MCP goto, daemon) inject unconditionally,
+      // so the gate has to live here, not just at the call site.
+      if (incognito) return 0;
+      return authenticate(page.session, url, { browser: cookieOpts?.browser });
     },
 
     async snapshot(pruneOpts) {
@@ -665,7 +686,8 @@ export async function connect(opts = {}) {
         },
         get botBlocked() { return tabBotBlocked; },
         async injectCookies(url, cookieOpts) {
-          await authenticate(tab.session, url, { browser: cookieOpts?.browser });
+          if (incognito) return 0;
+          return authenticate(tab.session, url, { browser: cookieOpts?.browser });
         },
         waitForNetworkIdle(idleOpts = {}) {
           return waitForNetworkIdle(tab.session, idleOpts);
@@ -738,6 +760,7 @@ async function connectFirefox(opts) {
     pruneMode: opts.pruneMode,
     urlGuard: { allowLocalUrls: opts.allowLocalUrls, blockPrivateNetwork: opts.blockPrivateNetwork },
     uploadDir: opts.uploadDir || null,
+    incognito: !!opts.incognito,
   });
   const closePage = page.close.bind(page);
   page.close = async () => {

--- a/src/readable.js
+++ b/src/readable.js
@@ -72,6 +72,45 @@ export function formatReadable(r) {
 }
 
 /**
+ * The in-page extraction expression (Readability injected + run). Exported so
+ * non-CDP transports (BiDi/Firefox) can evaluate the same source and feed the
+ * raw result through finalizeReadable() — keeping every engine's output
+ * identical.
+ */
+export { EXTRACT_EXPRESSION };
+
+/**
+ * Turn the raw in-page extraction result into the public readable() shape,
+ * applying the advisory confidence rule. Transport-agnostic.
+ * @param {object} r - raw result from EXTRACT_EXPRESSION
+ * @returns {object} public readable() result
+ */
+export function finalizeReadable(r) {
+  r = r || {};
+  if (!r.ok) {
+    return {
+      ok: false,
+      hint: r.err
+        ? `readable extraction failed (${r.err}); use snapshot()`
+        : 'no article content found on this page; use snapshot() instead',
+    };
+  }
+  // Advisory confidence: high only when the reader-view heuristic agrees AND
+  // there is a substantial amount of text. Low is not an error — the text is
+  // still returned; it just means "verify, or prefer snapshot()".
+  const confidence = r.readerable && r.length >= MIN_ARTICLE_CHARS ? 'high' : 'low';
+  const out = {
+    ok: true,
+    title: r.title, byline: r.byline, text: r.text, length: r.length,
+    readerable: r.readerable, confidence,
+  };
+  if (confidence === 'low') {
+    out.hint = 'low article confidence — this may not be an article; consider snapshot()';
+  }
+  return out;
+}
+
+/**
  * Extract the main article from the current page.
  * @param {object} session - CDP session-scoped handle (.send()).
  * @returns {Promise<object>} One of:
@@ -85,32 +124,5 @@ export async function readable(session) {
     returnByValue: true,
     awaitPromise: true,
   });
-  const r = result.value || {};
-
-  if (!r.ok) {
-    return {
-      ok: false,
-      hint: r.err
-        ? `readable extraction failed (${r.err}); use snapshot()`
-        : 'no article content found on this page; use snapshot() instead',
-    };
-  }
-
-  // Advisory confidence: high only when the reader-view heuristic agrees AND
-  // there is a substantial amount of text. Low is not an error — the text is
-  // still returned; it just means "verify, or prefer snapshot()".
-  const confidence = r.readerable && r.length >= MIN_ARTICLE_CHARS ? 'high' : 'low';
-  const out = {
-    ok: true,
-    title: r.title,
-    byline: r.byline,
-    text: r.text,
-    length: r.length,
-    readerable: r.readerable,
-    confidence,
-  };
-  if (confidence === 'low') {
-    out.hint = 'low article confidence — this may not be an article; consider snapshot()';
-  }
-  return out;
+  return finalizeReadable(result.value || {});
 }

--- a/test/integration/firefox.test.js
+++ b/test/integration/firefox.test.js
@@ -241,6 +241,48 @@ describe('connect({ engine: firefox }) — BiDi transport + AX reconstruction', 
     }
   });
 
+  it('nests multi-level iframes correctly (parent → child → grandchild + sibling)', async () => {
+    // Guards the positional iframe-splice on the hard case the single-level
+    // test doesn't cover: a grandchild frame plus a sibling frame must each
+    // land under their real parent, in document order.
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      await page.goto(data(`<main><h1>PARENT</h1>` +
+        `<iframe srcdoc="<h1>CHILD</h1><iframe srcdoc='&lt;h1&gt;GRANDCHILD&lt;/h1&gt;'></iframe>"></iframe>` +
+        `<iframe srcdoc="<h1>SIBLING</h1>"></iframe></main>`));
+      await new Promise((r) => setTimeout(r, 600));
+      const tree = treeOnly(await page.snapshot({ mode: 'read' }));
+      for (const label of ['PARENT', 'CHILD', 'GRANDCHILD', 'SIBLING']) {
+        assert.match(tree, new RegExp(label), `${label} present in the spliced tree`);
+      }
+      // GRANDCHILD must sit deeper than CHILD (real nesting, not flattened).
+      const indent = (l) => (tree.match(new RegExp(`^(\\s*)[^\\n]*${l}`, 'm')) || [, ''])[1].length;
+      assert.ok(indent('GRANDCHILD') > indent('CHILD'), 'GRANDCHILD nested under CHILD');
+    } finally {
+      await page.close();
+    }
+  });
+
+  it('switchTab() does not leak another tab\'s iframe into the active snapshot', async () => {
+    // Regression: allContexts() must be scoped to the active tab. Before the
+    // getTree({root}) fix, snapshotting tab B after switchTab spliced tab A's
+    // frame (INNER-A) into B's iframe and dropped INNER-B.
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      await page.goto(data('<title>TABA</title><main><h1>TABA</h1><iframe srcdoc="<h1>INNER-A</h1>"></iframe></main>'));
+      const created = await page.bidi.send('browsingContext.create', { type: 'tab' });
+      await page.bidi.send('browsingContext.navigate', { context: created.context, url: data('<title>TABB</title><main><h1>TABB</h1><iframe srcdoc="<h1>INNER-B</h1>"></iframe></main>'), wait: 'complete' });
+      await new Promise((r) => setTimeout(r, 400));
+      const tabs = await page.tabs();
+      await page.switchTab(tabs.findIndex((t) => /TABB/.test(t.title)));
+      const tree = treeOnly(await page.snapshot({ mode: 'read' }));
+      assert.match(tree, /INNER-B/, 'active tab B shows its own iframe content');
+      assert.doesNotMatch(tree, /INNER-A/, 'tab A iframe must NOT leak into tab B snapshot');
+    } finally {
+      await page.close();
+    }
+  });
+
   it('readable() returns the same result shape as the CDP path', async () => {
     const page = await connect({ engine: 'firefox', mode: 'headless' });
     try {

--- a/test/integration/firefox.test.js
+++ b/test/integration/firefox.test.js
@@ -12,6 +12,7 @@
 
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
 import { connect } from '../../src/index.js';
 import { findFirefox } from '../../src/firefox.js';
 
@@ -280,6 +281,54 @@ describe('connect({ engine: firefox }) — BiDi transport + AX reconstruction', 
       assert.doesNotMatch(tree, /INNER-A/, 'tab A iframe must NOT leak into tab B snapshot');
     } finally {
       await page.close();
+    }
+  });
+
+  it('does not expand a collapsed <select> option list into the tree', async () => {
+    // Regression: a native single <select> should surface as one combobox with
+    // its current value, NOT one node per <option> (a 200-item select bloats).
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      await page.goto(data('<select><option>Afghanistan</option><option>Belgium</option><option>Chad</option></select>'));
+      const tree = treeOnly(await page.snapshot({ mode: 'read' }));
+      assert.match(tree, /combobox/, 'select surfaces as a combobox');
+      assert.doesNotMatch(tree, /Belgium|Chad/, 'unselected options must not become nodes');
+    } finally {
+      await page.close();
+    }
+  });
+
+  it('keeps bare text directly under <body> (childNodes, not children)', async () => {
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      await page.goto(data('LOOSE-BODY-TEXT<div>wrapped</div>'));
+      const tree = treeOnly(await page.snapshot({ mode: 'read' }));
+      assert.match(tree, /LOOSE-BODY-TEXT/, 'bare body text must not be dropped');
+    } finally {
+      await page.close();
+    }
+  });
+
+  it('goto() rejects (does not hang) when a page never finishes loading', async () => {
+    // Regression: goto must honor its timeout. A server that accepts the
+    // request but never responds would hang navigate({wait:'complete'}) forever
+    // without the timeout race.
+    const held = [];
+    const server = createServer((_req, res) => { held.push(res); /* never end */ });
+    await new Promise((r) => server.listen(0, '127.0.0.1', r));
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      const started = Date.now();
+      await assert.rejects(
+        () => page.goto(`http://127.0.0.1:${server.address().port}/hang`, 2000),
+        /timed out/,
+        'goto must reject on a non-completing load',
+      );
+      assert.ok(Date.now() - started < 6000, 'rejects near the timeout, not much later');
+    } finally {
+      for (const r of held) { try { r.destroy(); } catch { /* ignore */ } }
+      await page.close();
+      server.close();
     }
   });
 

--- a/test/integration/firefox.test.js
+++ b/test/integration/firefox.test.js
@@ -1,0 +1,258 @@
+/**
+ * Integration tests for the Firefox / WebDriver BiDi path (connect({ engine:
+ * 'firefox' })). CDP is deprecated in Firefox, so Firefox is driven over BiDi
+ * with an in-page-reconstructed AX tree (ax-snapshot.js). These tests assert
+ * the reconstruction stays faithful to the CDP AX vocabulary that prune.js /
+ * aria.js expect, and that the hard cases (iframes, shadow DOM, CSP) hold.
+ *
+ * Requires a Firefox binary (>= 121). Skips cleanly if none is installed.
+ *
+ * Run: node --test test/integration/firefox.test.js
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { connect } from '../../src/index.js';
+import { findFirefox } from '../../src/firefox.js';
+
+const data = (html) => 'data:text/html,' + encodeURIComponent(html);
+/** Strip the leading `url:` echo line so assertions test the tree only. */
+const treeOnly = (snap) => snap.split('\n').filter((l) => !l.startsWith('url:')).join('\n');
+
+let hasFirefox = false;
+try { findFirefox(); hasFirefox = true; } catch { /* skip below */ }
+
+describe('connect({ engine: firefox }) — BiDi transport + AX reconstruction', { skip: !hasFirefox && 'no Firefox installed' }, () => {
+  it('reconstructs accessible names the way getFullAXTree would', async () => {
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      await page.goto(data(`<main>
+        <h1>Welcome</h1>
+        <img src="x.png" alt="Company logo">
+        <label>Email <input id="email" type="text"></label>
+        <button aria-labelledby="l1"></button><span id="l1">Submit form</span>
+        <a href="/next">Read more</a>
+        <div aria-hidden="true"><button>INVISIBLE</button></div>
+      </main>`));
+      const tree = treeOnly(await page.snapshot({ mode: 'browse' }));
+
+      assert.match(tree, /image "Company logo"/, 'img alt → accessible name');
+      assert.match(tree, /textbox "Email/, '<label> → input accessible name');
+      assert.match(tree, /button "Submit form"/, 'aria-labelledby → button name');
+      assert.match(tree, /link "Read more"/, 'link name from content');
+      assert.match(tree, /heading "Welcome"/, 'heading name from content');
+      assert.doesNotMatch(tree, /INVISIBLE/, 'aria-hidden subtree filtered out');
+    } finally {
+      await page.close();
+    }
+  });
+
+  it('types into a field via faithful BiDi key events', async () => {
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      await page.goto(data(`<label>Q <input id="q" type="text"></label>`));
+      const snap = treeOnly(await page.snapshot());
+      const ref = snap.match(/textbox[^\n]*\[ref=(\d+)\]/);
+      assert.ok(ref, 'snapshot exposes a textbox ref');
+      await page.type(ref[1], 'hello@test.com');
+      const value = await page.bidi.evaluate(page.context, 'document.getElementById("q").value', false);
+      assert.equal(value, 'hello@test.com', 'type() wrote through real key events');
+    } finally {
+      await page.close();
+    }
+  });
+
+  it('splices an iframe subtree and routes clicks into it', async () => {
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      await page.goto(data(`<main><h1>Parent</h1>
+        <iframe srcdoc="<button>Inner Button</button>"></iframe></main>`));
+      await new Promise((r) => setTimeout(r, 400));
+      const tree = treeOnly(await page.snapshot({ mode: 'browse' }));
+      assert.match(tree, /button "Inner Button"/, 'iframe content spliced into parent tree');
+      const ref = tree.match(/button "Inner Button"[^\n]*\[ref=(\d+)\]/);
+      assert.ok(ref, 'inner button has a ref');
+      // Click must resolve in the child context, not throw "unknown ref".
+      await page.click(ref[1]);
+    } finally {
+      await page.close();
+    }
+  });
+
+  it('traverses open shadow roots (getFullAXTree parity)', async () => {
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      await page.goto(data(`<div id="host"></div>
+        <script>document.getElementById('host').attachShadow({mode:'open'}).innerHTML='<button>Shadow Button</button>';</script>`));
+      await new Promise((r) => setTimeout(r, 200));
+      const tree = treeOnly(await page.snapshot({ mode: 'browse' }));
+      assert.match(tree, /Shadow Button/, 'shadow-root content is visible in the snapshot');
+    } finally {
+      await page.close();
+    }
+  });
+
+  it('reconstructs the tree under a strict CSP (script.evaluate in an isolated realm)', async () => {
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      await page.goto(data(`<head><meta http-equiv="Content-Security-Policy" content="script-src 'none'; default-src 'none'"></head>
+        <body><main><h1>CSP Locked</h1><button>Guarded</button></main></body>`));
+      const tree = treeOnly(await page.snapshot({ mode: 'browse' }));
+      assert.match(tree, /CSP Locked/, 'snapshot works despite script-src none');
+      assert.match(tree, /button "Guarded"/, 'interactive element still captured under CSP');
+    } finally {
+      await page.close();
+    }
+  });
+
+  it('press / scroll / hover drive real input events', async () => {
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      // press(Enter) submits a form
+      await page.goto(data(`<main><form onsubmit="document.title='SENT';return false"><input id="i" type="text"></form></main>`));
+      let ref = treeOnly(await page.snapshot()).match(/textbox[^\n]*\[ref=(\d+)\]/);
+      await page.type(ref[1], 'x');
+      await page.press('Enter');
+      await new Promise((r) => setTimeout(r, 100));
+      assert.equal(await page.bidi.evaluate(page.context, 'document.title', false), 'SENT', 'press(Enter) submits');
+
+      // scroll() moves the viewport
+      await page.goto(data(`<body style="height:5000px"><div style="margin-top:3000px">x</div></body>`));
+      await page.scroll(1200);
+      await new Promise((r) => setTimeout(r, 100));
+      assert.ok(await page.bidi.evaluate(page.context, 'window.scrollY', false) > 500, 'scroll moves viewport');
+
+      // hover() fires mouseover
+      await page.goto(data(`<main><button id="b" onmouseover="this.textContent='HOV'">rest</button></main>`));
+      const bref = treeOnly(await page.snapshot()).match(/button[^\n]*\[ref=(\d+)\]/);
+      await page.hover(bref[1]);
+      await new Promise((r) => setTimeout(r, 100));
+      assert.equal(await page.bidi.evaluate(page.context, 'document.getElementById("b").textContent', false), 'HOV', 'hover fires mouseover');
+    } finally {
+      await page.close();
+    }
+  });
+
+  it('keeps a top-level landmark that has no <main> (CDP parity — F: body-wrapper)', async () => {
+    // Regression: without the ignored body wrapper, a top-level <form> (a
+    // landmark) was treated as a directly-extractable region and dropped in
+    // act mode, diverging from CDP which buries it under body.
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      await page.goto(data(`<form onsubmit="return false"><input type="text"></form>`));
+      const tree = treeOnly(await page.snapshot()); // default act mode
+      assert.match(tree, /form/, 'top-level form survives act-mode pruning');
+      assert.match(tree, /textbox/, 'its field survives too');
+    } finally {
+      await page.close();
+    }
+  });
+
+  it('goto() enforces the navigation guard (blocks local schemes, allows data:)', async () => {
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      await assert.rejects(
+        () => page.goto('file:///etc/passwd'),
+        /local|file|scheme|navigat|blocked/i,
+        'file:// must be blocked — same guard the CDP path enforces',
+      );
+      // A normal data: URL must still navigate (guard is not over-broad).
+      await page.goto('data:text/html,<h1>ok</h1>');
+    } finally {
+      await page.close();
+    }
+  });
+
+  it('navigation history: goBack / goForward / reload', async () => {
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      await page.goto(data('<main><h1>Page A</h1></main>'));
+      await page.goto(data('<main><h1>Page B</h1></main>'));
+      await page.goBack();
+      assert.match(await page.snapshot({ mode: 'browse' }), /Page A/, 'goBack');
+      await page.goForward();
+      assert.match(await page.snapshot({ mode: 'browse' }), /Page B/, 'goForward');
+      await page.goto(data('<main><h1 id="h">Fresh</h1><script>document.getElementById("h").textContent="Mutated"</script></main>'));
+      await page.reload();
+      assert.match(await page.snapshot({ mode: 'browse' }), /Mutated/, 'reload re-runs scripts');
+    } finally {
+      await page.close();
+    }
+  });
+
+  it('select / drag / upload act on the right elements', async () => {
+    const { writeFileSync, mkdtempSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      // native select
+      await page.goto(data('<main><select id="s"><option>Red</option><option>Green</option></select></main>'));
+      const sref = treeOnly(await page.snapshot()).match(/combobox[^\n]*\[ref=(\d+)\]/)[1];
+      await page.select(sref, 'Green');
+      assert.equal(await page.bidi.evaluate(page.context, 'document.getElementById("s").value', false), 'Green');
+
+      // drag between two resolvable elements (does not throw)
+      await page.goto(data('<main><button>A</button><button>B</button></main>'));
+      const bRefs = [...treeOnly(await page.snapshot()).matchAll(/button[^\n]*\[ref=(\d+)\]/g)].map((m) => m[1]);
+      await page.drag(bRefs[0], bRefs[1]);
+
+      // upload
+      const dir = mkdtempSync(join(tmpdir(), 'ff-up-'));
+      const f = join(dir, 'a.txt'); writeFileSync(f, 'hi');
+      await page.goto(data('<main><input id="f" type="file"></main>'));
+      const anyRef = [...(await page.snapshot(false)).matchAll(/\[ref=(\d+)\]/g)].map((m) => m[1]).pop();
+      await page.upload(anyRef, [f]);
+      assert.equal(await page.bidi.evaluate(page.context, 'document.getElementById("f").files.length', false), 1);
+    } finally {
+      await page.close();
+    }
+  });
+
+  it('screenshot() and pdf() return valid base64 payloads', async () => {
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      await page.goto(data('<main><h1>Shot</h1></main>'));
+      const png = await page.screenshot();
+      assert.ok(Buffer.from(png, 'base64').slice(1, 4).toString() === 'PNG', 'PNG magic bytes');
+      const pdf = await page.pdf();
+      assert.equal(Buffer.from(pdf, 'base64').slice(0, 5).toString(), '%PDF-', 'PDF magic bytes');
+    } finally {
+      await page.close();
+    }
+  });
+
+  it('tabs() / switchTab() / waitFor() operate across contexts', async () => {
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      const created = await page.bidi.send('browsingContext.create', { type: 'tab' });
+      await page.bidi.send('browsingContext.navigate', { context: created.context, url: data('<title>Second</title><main><h1>Second</h1></main>'), wait: 'complete' });
+      const tabs = await page.tabs();
+      assert.ok(tabs.length >= 2, 'lists both tabs');
+      await page.switchTab(tabs.findIndex((t) => /Second/.test(t.title)));
+      assert.match(await page.snapshot({ mode: 'browse' }), /Second/, 'switchTab retargets snapshot');
+
+      await page.switchTab(0);
+      await page.goto(data('<main id="app"><h1>Wait</h1></main><script>setTimeout(()=>app.innerHTML="<button>Ready</button>",300)</script>'));
+      await page.waitFor({ text: 'Ready', timeout: 3000 });
+      assert.match(await page.snapshot({ mode: 'browse' }), /Ready/, 'waitFor resolves on late text');
+    } finally {
+      await page.close();
+    }
+  });
+
+  it('readable() returns the same result shape as the CDP path', async () => {
+    const page = await connect({ engine: 'firefox', mode: 'headless' });
+    try {
+      await page.goto(data(`<article><h1>Title</h1><p>${'Real prose. '.repeat(200)}</p></article>`));
+      const r = await page.readable();
+      assert.equal(typeof r.ok, 'boolean', 'has ok flag');
+      if (r.ok) {
+        assert.equal(typeof r.text, 'string');
+        assert.ok(['high', 'low'].includes(r.confidence), 'advisory confidence present');
+      }
+    } finally {
+      await page.close();
+    }
+  });
+});

--- a/test/integration/incognito.test.js
+++ b/test/integration/incognito.test.js
@@ -1,0 +1,118 @@
+/**
+ * Integration tests for incognito mode — a clean, unauthenticated session that
+ * skips ALL auth injection (storageState + injectCookies).
+ *
+ * Deterministic and self-contained: uses a controlled storageState cookie, not
+ * the user's real browser cookies, so results don't depend on machine state.
+ *
+ * Run: node --test test/integration/incognito.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { connect } from '../../src/index.js';
+import { extractCookies } from '../../src/auth.js';
+import { findFirefox } from '../../src/firefox.js';
+
+let hasFirefox = false;
+try { findFirefox(); hasFirefox = true; } catch { /* firefox arm skips */ }
+
+// A storageState file carrying one known cookie for example.com. Both arms load
+// the SAME file — the only difference is the incognito flag, so if the cookie's
+// presence differs, incognito is the cause (the test can fail if the gate is a
+// no-op).
+function writeStorageState() {
+  const dir = mkdtempSync(join(tmpdir(), 'bb-incognito-'));
+  const file = join(dir, 'state.json');
+  const future = Math.floor(Date.now() / 1000) + 3600;
+  writeFileSync(file, JSON.stringify({
+    cookies: [{
+      name: 'bb_incognito_probe', value: 'present', domain: 'example.com',
+      path: '/', secure: true, httpOnly: false, sameSite: 'None', expires: future,
+    }],
+  }));
+  return file;
+}
+
+async function probeCookiePresent(page) {
+  const { cookies } = await page.cdp.send('Network.getAllCookies');
+  return cookies.some((c) => c.name === 'bb_incognito_probe');
+}
+
+describe('incognito mode', () => {
+  it('DEFAULT: loads storageState cookies into the session', async () => {
+    const storageState = writeStorageState();
+    const page = await connect({ mode: 'headless', storageState });
+    try {
+      assert.equal(await probeCookiePresent(page), true,
+        'control: storageState cookie must be present without incognito');
+    } finally {
+      await page.close();
+    }
+  });
+
+  it('INCOGNITO: skips storageState — no auth cookie enters the session', async () => {
+    const storageState = writeStorageState();
+    const page = await connect({ mode: 'headless', storageState, incognito: true });
+    try {
+      assert.equal(await probeCookiePresent(page), false,
+        'incognito must NOT load the storageState cookie');
+    } finally {
+      await page.close();
+    }
+  });
+
+  it('INCOGNITO: injectCookies() is a no-op that returns 0', async () => {
+    // Deterministic regardless of machine cookies: incognito short-circuits
+    // BEFORE authenticate() (which would otherwise throw on no-cookies or
+    // inject real ones). A non-incognito session instead reaches authenticate().
+    const page = await connect({ mode: 'headless', incognito: true });
+    try {
+      const before = (await page.cdp.send('Network.getAllCookies')).cookies.length;
+      const result = await page.injectCookies('https://example.com/');
+      const after = (await page.cdp.send('Network.getAllCookies')).cookies.length;
+      assert.equal(result, 0, 'incognito injectCookies() should report 0 injected');
+      assert.equal(after, before, 'incognito injectCookies() must not add cookies');
+    } finally {
+      await page.close();
+    }
+  });
+});
+
+// The Firefox/BiDi engine has its own page object and injectCookies path, so
+// incognito parity must be proven there too — this is the gap that paused the
+// release. storageState is CDP-only, so the Firefox arm gates injectCookies.
+describe('incognito mode — Firefox/BiDi engine', { skip: !hasFirefox && 'no Firefox installed' }, () => {
+  it('INCOGNITO: injectCookies() is a no-op — no cookie enters the session', async () => {
+    // Control (only if the user has Firefox cookies): non-incognito injection
+    // lands cookies, proving the incognito suppression below is meaningful.
+    let sample;
+    try { sample = extractCookies({ browser: 'firefox' }).find((c) => c.domain && c.name); } catch { /* none */ }
+
+    const incog = await connect({ engine: 'firefox', incognito: true });
+    try {
+      const n = await incog.injectCookies('https://example.com', { browser: 'firefox' });
+      assert.equal(n, 0, 'incognito injectCookies() returns 0 on Firefox');
+      const store = await incog.bidi.send('storage.getCookies', {});
+      assert.equal(store.cookies.length, 0, 'no cookies entered the incognito Firefox session');
+    } finally {
+      await incog.close();
+    }
+
+    if (sample) {
+      const domain = sample.domain.replace(/^\./, '');
+      const control = await connect({ engine: 'firefox' });
+      try {
+        await control.injectCookies('https://' + domain, { browser: 'firefox', domain });
+        const store = await control.bidi.send('storage.getCookies', {});
+        assert.ok(store.cookies.length > 0,
+          'control: non-incognito Firefox injection lands cookies — proves the gate matters');
+      } finally {
+        await control.close();
+      }
+    }
+  });
+});

--- a/test/unit/auth.test.js
+++ b/test/unit/auth.test.js
@@ -7,7 +7,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { extractCookies, cookieDomainMatch } from '../../src/auth.js';
+import { extractCookies, cookieDomainMatch, scopedCookiesForUrl } from '../../src/auth.js';
 
 // extractCookies() reads the real on-disk browser cookie database; skip when
 // none exists (e.g. a CI runner with no browser profile). The pure
@@ -89,5 +89,35 @@ describe('cookieDomainMatch() — precise injection filter', () => {
 
   it('is case-insensitive', () => {
     assert.equal(cookieDomainMatch('Mail.Google.COM', '.GOOGLE.com'), true);
+  });
+});
+
+// Shared scoping used by BOTH engines (CDP authenticate + Firefox injectCookies).
+// The invariant — every returned cookie matches the URL host — holds regardless
+// of which cookies this machine has, and fails loudly if the domain filter is
+// ever dropped (the Firefox v0.15.0 whole-jar bug).
+describe('scopedCookiesForUrl() — cross-engine cookie scoping', { skip: cookiesSkip }, () => {
+  it('returns only cookies whose domain matches the URL host', () => {
+    // Pick a host the jar actually owns, so scoping yields a real (non-empty)
+    // set — then assert every cookie in it matches that host. Fails loudly if
+    // the domain filter is ever dropped (the Firefox whole-jar bug).
+    const sample = extractCookies().find((c) => c.domain);
+    if (!sample) return;
+    const host = sample.domain.replace(/^\./, '');
+    const scoped = scopedCookiesForUrl(`https://${host}/`);
+    assert.ok(scoped.length > 0, 'a host that owns cookies must yield a non-empty scoped set');
+    for (const c of scoped) {
+      assert.ok(cookieDomainMatch(host, c.domain),
+        `leaked out-of-scope cookie for ${c.domain} when scoping to ${host}`);
+    }
+  });
+
+  it('yields nothing for a host that owns no cookies', () => {
+    // extractCookies throws "No browser cookie database found" when a domain
+    // matches zero rows (existing quirk shared with CDP authenticate — callers
+    // wrap in try/catch). Either way, the effective scoped set is empty.
+    let scoped = [];
+    try { scoped = scopedCookiesForUrl('https://no-such-host.invalid-tld-zzz/'); } catch { scoped = []; }
+    assert.equal(scoped.length, 0, 'an unowned host must contribute no cookies');
   });
 });

--- a/test/unit/daemon.test.js
+++ b/test/unit/daemon.test.js
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for the daemon child-arg contract (buildDaemonArgs).
+ *
+ * Regression guard for the v0.15.0 bug where `--incognito` was never forwarded
+ * to the detached daemon child, so `barebrowse open <url> --incognito` silently
+ * ran a fully-authenticated session. A dropped forward here is now a red test,
+ * not a silent auth leak.
+ *
+ * Run: node --test test/unit/daemon.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildDaemonArgs } from '../../src/daemon.js';
+
+const CLI = '/x/cli.js';
+
+describe('buildDaemonArgs', () => {
+  it('forwards --incognito when opts.incognito is set', () => {
+    const args = buildDaemonArgs({ incognito: true }, '/out', undefined, CLI);
+    assert.ok(args.includes('--incognito'), 'incognito must reach the daemon child');
+  });
+
+  it('omits --incognito when not set (default authenticated session)', () => {
+    const args = buildDaemonArgs({}, '/out', undefined, CLI);
+    assert.ok(!args.includes('--incognito'), 'no incognito flag by default');
+  });
+
+  it('forwards --no-cookies (the sibling auth-suppression flag)', () => {
+    const args = buildDaemonArgs({ cookies: false }, '/out', undefined, CLI);
+    assert.ok(args.includes('--no-cookies'));
+  });
+
+  it('carries the core plumbing: cli path, daemon-internal, output dir, url', () => {
+    const args = buildDaemonArgs({ engine: 'firefox', mode: 'headed' }, '/out', 'https://e.com', CLI);
+    assert.equal(args[0], CLI);
+    assert.ok(args.includes('--daemon-internal'));
+    assert.deepEqual(args.slice(args.indexOf('--output-dir'), args.indexOf('--output-dir') + 2), ['--output-dir', '/out']);
+    assert.deepEqual(args.slice(args.indexOf('--url'), args.indexOf('--url') + 2), ['--url', 'https://e.com']);
+    assert.deepEqual(args.slice(args.indexOf('--engine'), args.indexOf('--engine') + 2), ['--engine', 'firefox']);
+  });
+});


### PR DESCRIPTION
## v0.15.0 — Firefox/BiDi engine + incognito clean session

Two features, released together after a full pre-merge review pass.

### Firefox support via WebDriver BiDi (`connect({ engine: 'firefox' })`)
Second transport (`src/bidi.js`) over the same `ws` dep — no geckodriver, no new package. AX tree reconstructed in-page (`src/ax-snapshot.js`) since BiDi has no `getFullAXTree`. `prune.js`/`aria.js`/`readable.js` reused verbatim. CLI `--engine firefox`, MCP `BAREBROWSE_ENGINE=firefox`.

### Incognito clean session (`incognito: true`)
Skips **all** auth injection (cookies + `storageState`) for a logged-out session. Gate enforced at the page-object level, so it holds even when a caller injects unconditionally (MCP `goto`, daemon). On `browse()`, `connect()`, both engines, MCP (`browse` arg + `BAREBROWSE_INCOGNITO=1`), CLI (`--incognito`).

### Review pass — found + fixed (each validated first)
- **HIGH:** `startDaemon` never forwarded `--incognito` to the daemon child → `open --incognito` silently authenticated. Fixed via pure, unit-tested `buildDaemonArgs()`.
- **HIGH:** Firefox `injectCookies` loaded the whole cookie jar (ignored the URL). Fixed via shared `scopedCookiesForUrl()` used by both engines so they can't drift.
- **Bug:** Firefox iframe splice leaked another tab's frame after `switchTab()` (POC-proven). Fixed by scoping `allContexts()` to the active tab (`getTree({ root })`). Nested-frame handling was already correct. Regression tests added.
- **Parity:** Firefox stubs the 5 CDP-only daemon methods with clear "not supported" errors / empty logs instead of silent `TypeError`s.

### Verification
- `npm test` — **193 pass, 0 fail**
- `npm run typecheck` — clean
- `/ship` + `/security` + `/diff-review` gates run under `/verify-done`

### Known gaps (Firefox engine, documented)
Consent auto-dismiss, ad-block, stealth, `hybrid` mode, `reload({ignoreCache})`, console/network capture, `saveState`/`waitForNavigation`/`waitForNetworkIdle` are Chromium-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZpPPhwXmSfN1n7uX7RAxT
