### PR TITLE
fix(firefox): consent false-positive guard (v0.16.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.16.1] - 2026-07-10
+
+### Fixed
+
+- **Firefox consent auto-dismiss no longer risks clicking an unrelated button.**
+  A code review of v0.16.0 found (and reproduced) a false-positive: when a
+  consent *dialog* was detected but contained no in-dialog accept button, the
+  Firefox walker fell back to a page-wide "accept" scan that could auto-click an
+  unrelated `Accept all …` control elsewhere on the page (e.g. a ToS/signup
+  button) during `goto()`. The page-wide scan now runs **only** for banner-style
+  consent (no dialog container at all). Trade-off: an accept button rendered
+  *outside* its own dialog (some SourcePoint deployments) is no longer
+  auto-dismissed on Firefox — we accept that miss rather than risk a wrong
+  click. Regression-tested in `test/unit/consent-firefox.test.js`.
+
+### Documentation
+
+- **Firefox stealth + consent known limitations** captured in the PRD
+  (`docs/01-product/prd.md`), slated for the Phase 5 cross-engine fidelity
+  harness: the consent double AX-build per navigate (bounded latency, parity
+  with CDP), the single-click-without-re-verify behavior (`consent: false` to
+  opt out), and the latent `navigator.webdriver` own-property fallback. All
+  three were validated in the same review; none is a correctness defect on
+  current engines.
+
 ## [0.16.0] - 2026-07-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ const page = await connect({ engine: 'firefox' }); // headless by default
 
 From the CLI: `barebrowse open <url> --engine firefox`. From MCP: set
 `BAREBROWSE_ENGINE=firefox`. Firefox cookies (plaintext) reuse into the same
-engine. Chromium (CDP) remains the default; `hybrid` mode is Chromium-only.
+engine. Consent auto-dismiss and headless stealth work on Firefox too (as of
+v0.16.0). Chromium (CDP) remains the default; `hybrid` mode, ad/tracker
+blocking, and the daemon's console/network capture are still Chromium-only.
 
 No clone profile, no fresh cookies — the agent sees what you see.
 

--- a/barebrowse.context.md
+++ b/barebrowse.context.md
@@ -189,8 +189,8 @@ barebrowse can inject cookies from the user's real browser sessions, bypassing l
 
 | Obstacle | How | Mode |
 |---|---|---|
-| Cookie consent | ARIA scan + jsClick accept button, 29 languages | Both |
-| Consent behind iframes | JS `.click()` via DOM.resolveNode bypasses overlays, real mouse click fallback for CMPs that ignore synthetic clicks | Both |
+| Cookie consent | ARIA scan for the accept button, 29 languages. CDP: `jsClick` (overlay-bypassing) then a real-mouse-click fallback for CMPs that ignore synthetic clicks. Firefox/BiDi: a single real pointer click. A page-wide accept scan runs only for banner-style consent (no dialog) — when a dialog is detected but has no in-dialog accept button, no page-wide scan runs, to avoid clicking an unrelated `Accept all …` control | Both engines |
+| Consent behind iframes | Scanned/clicked in the owning frame (CDP `DOM.resolveNode`; Firefox resolves the ref in its browsing context) | Both engines |
 | Permission prompts | Launch flags + CDP Browser.setPermission auto-deny | Both |
 | Media autoplay blocked | `--autoplay-policy=no-user-gesture-required` | Both |
 | Login walls | Cookie extraction from Firefox/Chromium + CDP injection | Both |

--- a/docs/01-product/prd.md
+++ b/docs/01-product/prd.md
@@ -317,6 +317,36 @@ This section exists so we don't re-debate settled decisions.
 
 ### Medium-term
 - **Firefox support** — *(Done: `connect({ engine: 'firefox' })` drives Firefox over WebDriver BiDi via `bidi.js` + `firefox.js`, with the AX tree reconstructed in-page by `ax-snapshot.js`. Covers `goto`, `snapshot`, `click`, `type`, `press`, `scroll`, `hover`, `select`, `drag`, `upload`, `goBack`/`goForward`, `reload`, `screenshot`, `pdf`, `tabs`/`switchTab`, `waitFor`, `readable`, `injectCookies`, `close`. Selectable from MCP via `BAREBROWSE_ENGINE=firefox` and from the CLI via `barebrowse open --engine firefox`. Verified for accname fidelity, iframes, shadow DOM, CSP, SPA timing, navigation, capture, and the CLI/MCP paths in `test/integration/firefox.test.js` + smoke tests. **Known gaps:** consent auto-dismiss and stealth landed on Firefox in v0.16.0 (BiDi parity Phase 1); hybrid fallback, ad/tracker blocking, and the daemon's console/network capture remain chromium-only; accname is a high-value subset of the W3C spec; and `reload` can't honour `ignoreCache` (Firefox BiDi doesn't support it yet).)*
+
+  **Known limitations — Firefox stealth + consent (v0.16.0, validated in a code
+  review; slated for Phase 5 revisit with a cross-engine fidelity harness):**
+  - *Consent false-positive — **fixed** in v0.16.0.* The page-wide accept-button
+    scan now runs **only** for banner-style consent (no dialog container). When a
+    consent dialog is detected but has no in-dialog accept button, barebrowse no
+    longer scans the whole page — a page-wide match there could auto-click an
+    unrelated "Accept all …" control (e.g. a ToS/signup button) on `goto()`.
+    Trade-off: the rare pattern of an accept button rendered *outside* its own
+    dialog (some SourcePoint deployments) is no longer auto-dismissed on Firefox;
+    we accept that miss rather than risk a wrong click. Regression-tested in
+    `test/unit/consent-firefox.test.js`. (The CDP path still does the page-wide
+    scan and carries the original false-positive risk — unchanged here.)
+  - *Consent double AX build (performance).* With consent on (default), each
+    `goto()` reconstructs the AX tree once for the consent scan and `snapshot()`
+    rebuilds it — two in-page reconstructions per navigate. Bounded latency
+    (page-size dependent), no correctness impact; parity with the CDP path's
+    `getFullAXTree`-per-navigate. Not optimised because the safe options (a
+    cheap consent probe, tree caching) risk consent coverage or stale trees.
+  - *Consent single-click, no re-verify.* The Firefox walker clicks the accept
+    button once (a real BiDi pointer event) and does not re-check dismissal or
+    retry, unlike the CDP path's synthetic-then-real retry. A CMP that ignores
+    the first click stays up (the flow "fails open" — page loads, wall remains);
+    low likelihood since the click is already a real pointer event. Disable with
+    `consent: false` where an auto-click is unacceptable.
+  - *webdriver own-property fallback (latent).* `WEBDRIVER_PATCH` deletes
+    `navigator.webdriver` off `Navigator.prototype`; if a browser ever exposed
+    it as an *own* property instead, the delete would miss it and the
+    `defineProperty` fallback would restore the `hasOwnProperty` tell. Does not
+    occur on current Chromium/Firefox (prototype property), so it is latent.
 - **Cookie sync** — In hybrid mode, extract fresh cookies from headed session and cache for future headless use. Self-refreshing auth.
 - **Selector discovery** — Port sweetlink's `discoverSelectors` — crawl ARIA tree, score interactive elements, return ranked action targets.
 - **Form understanding** — Detect forms in ARIA tree, map fields to semantic purposes, enable agents to fill forms intelligently.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "barebrowse",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "barebrowse",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "barebrowse",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Authenticated web browsing for autonomous agents via CDP. URL in, pruned ARIA snapshot out.",
   "repository": {
     "type": "git",

--- a/src/consent-firefox.js
+++ b/src/consent-firefox.js
@@ -102,15 +102,23 @@ export async function dismissConsentFirefox(root, click) {
     }
   }
 
-  // No dialog (banner-style consent) or dialog with no in-scope button: fall
-  // back to a page-wide strong-pattern scan.
-  const global = findGlobalAcceptButton(root);
-  if (global?.nodeId) {
-    try {
-      await click(global.nodeId);
-      return true;
-    } catch {
-      return false;
+  // Banner-style consent (no dialog container at all): scan the page for a
+  // strong accept button. We deliberately DO NOT run this page-wide scan when a
+  // consent dialog WAS detected but had no in-scope accept button — a page-wide
+  // match there can click an UNRELATED "Accept all …" control elsewhere (e.g. a
+  // ToS/signup button), an automatic wrong mutation on goto(). The trade-off is
+  // losing the rare "accept button rendered outside its own dialog" pattern; we
+  // accept that miss rather than risk a wrong click. See the PRD "known
+  // limitations" note for the validated false-positive this guards against.
+  if (consentDialogs.length === 0) {
+    const global = findGlobalAcceptButton(root);
+    if (global?.nodeId) {
+      try {
+        await click(global.nodeId);
+        return true;
+      } catch {
+        return false;
+      }
     }
   }
   return false;

--- a/test/unit/consent-firefox.test.js
+++ b/test/unit/consent-firefox.test.js
@@ -107,6 +107,26 @@ describe('dismissConsentFirefox — banner fallback', () => {
     assert.equal(await dismissConsentFirefox(root, spy.fn), false);
     assert.deepEqual(spy.clicked, [], 'no click on an ordinary OK button');
   });
+
+  it('does NOT page-wide scan when a dialog was detected but had no accept button', async () => {
+    counter = 0;
+    // Regression for the validated false-positive: a consent dialog IS detected
+    // (cookie text) but has no in-dialog accept button, while an UNRELATED
+    // "Accept all terms" button sits elsewhere on the page. The page-wide scan
+    // must NOT fire here — clicking that unrelated button would be an automatic
+    // wrong mutation. (We accept missing the rare outside-the-dialog button.)
+    const unrelated = node('button', 'Accept all terms');
+    const root = node('RootWebArea', '', [
+      node('dialog', 'Cookie notice', [
+        node('StaticText', 'We use cookies.'),
+        node('button', 'Manage preferences'), // no accept-pattern match
+      ]),
+      node('form', 'Signup', [unrelated]),
+    ]);
+    const spy = spyClick();
+    assert.equal(await dismissConsentFirefox(root, spy.fn), false);
+    assert.deepEqual(spy.clicked, [], 'must not click the unrelated Accept-all-terms button');
+  });
 });
 
 describe('dismissConsentFirefox — no-op cases', () => {


### PR DESCRIPTION
Follow-up to v0.16.0 from its code review. Fixes a validated (reproduced)
false-positive in the Firefox consent walker, and records the other review
findings as PRD known limitations.

## Fix
When a consent **dialog** was detected but had no in-dialog accept button, the
Firefox walker fell back to a **page-wide** accept scan that could auto-click an
unrelated `Accept all …` control (e.g. a ToS/signup button) on `goto()`. The
page-wide scan now runs **only** for banner-style consent (no dialog container).

**Trade-off:** an accept button rendered *outside* its own dialog (some
SourcePoint deployments) is no longer auto-dismissed on Firefox — we accept the
miss rather than risk a wrong click.

## Tests
- New regression test in `test/unit/consent-firefox.test.js` (fails before the
  fix: it clicked the unrelated button).
- Full suite **211/211**, `tsc --noEmit` clean. FF consent auto-dismiss on a
  normal dialog still works (integration 23/23).

## Docs
- CHANGELOG `[0.16.1]`; README + context guide note the Firefox consent scoping.
- PRD "Known limitations (v0.16.0)": documents the other three validated
  findings (consent double AX-build, single-click-no-reverify, latent webdriver
  own-property fallback) for the Phase 5 fidelity harness — none a correctness
  defect on current engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)