### PR TITLE
release: v0.19.2 — Firefox saveState/eval/console fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.19.2] - 2026-07-11
+
+### Fixed
+
+- **Firefox `saveState()` now writes `sameSite` capitalized** (`Lax`/`Strict`/`None`,
+  was BiDi's lowercase `lax`/`strict`/`none`). The only loader for a state file is
+  `connect({ storageState })`, which is CDP-only (`Network.setCookies`) and rejects
+  a lowercase enum — so the whole batch threw and every cookie was silently dropped,
+  making a Firefox-saved state useless for auth restore. Found by `/code-review` and
+  confirmed against real Firefox.
+- **Firefox CLI/daemon `eval` accepts statement-form expressions again**
+  (`var x = 2; x * 3`). A Phase-4 wrapper (`await (${expr})`, added to flatten
+  objects) turned every statement list into a `SyntaxError` — a regression versus
+  the CDP `Runtime.evaluate` path. Now evaluates the raw expression (BiDi
+  `script.evaluate` has eval-semantics) and deserializes the `{type,value}` remote
+  value back to the plain value CDP's `returnByValue` yields, so deep objects stay
+  clean *and* statements work.
+- **Firefox daemon console capture no longer dumps nested serialization** for
+  object/array console arguments — it falls back to the type name, matching the CDP
+  capture's `RemoteObject.description` ("Object").
+
 ## [0.19.1] - 2026-07-11
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "barebrowse",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "barebrowse",
-      "version": "0.19.1",
+      "version": "0.19.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "barebrowse",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Authenticated web browsing for autonomous agents via CDP. URL in, pruned ARIA snapshot out.",
   "repository": {
     "type": "git",

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -68,6 +68,31 @@ export function buildDaemonArgs(opts, absDir, initialUrl, cliPath) {
 }
 
 /**
+ * Convert a BiDi remote value ({type,value} — see script.evaluate) into the
+ * plain JS value CDP's `Runtime.evaluate({returnByValue:true})` yields, so an
+ * `eval` returns the same shape on both engines. BiDi serializes objects/arrays
+ * as entry lists ([[k,v],…] / [v,…]) rather than plain values; walk them back.
+ * @param {object} r - BiDi remote value
+ * @returns {*}
+ */
+export function deserializeBiDi(r) {
+  if (!r || typeof r !== 'object') return r;
+  switch (r.type) {
+    case 'undefined': return undefined;
+    case 'null': return null;
+    case 'string': case 'number': case 'boolean': case 'bigint': return r.value;
+    case 'array': case 'set': return (r.value || []).map(deserializeBiDi);
+    case 'object': case 'map':
+      return Object.fromEntries(
+        (r.value || []).map(([k, v]) => [typeof k === 'object' ? deserializeBiDi(k) : k, deserializeBiDi(v)]),
+      );
+    // date/regexp/node/function/etc. — no plain-value equivalent; use the raw
+    // value if BiDi provided one, else the type name (matches CDP's coarseness).
+    default: return r.value !== undefined ? r.value : r.type;
+  }
+}
+
+/**
  * Wire Firefox/BiDi console + network capture onto the daemon's log arrays.
  * The BiDi analogue of the CDP `Runtime.consoleAPICalled` / `Network.*`
  * capture — measured event shapes: `log.entryAdded` carries {method, level,
@@ -99,8 +124,12 @@ export async function attachBiDiCapture(bidi, { consoleLogs, networkLogs, pendin
       // engines — BiDi says 'warn', CDP says 'warning'.
       type: e.method === 'warn' ? 'warning' : (e.method || e.level),
       timestamp: new Date().toISOString(),
+      // Primitive args carry a usable `.value`; objects/arrays/functions carry a
+      // nested {type,value} serialization we must NOT splat into the log (it's
+      // deep junk) — fall back to the type name, mirroring the CDP capture which
+      // logs a RemoteObject's `.description` ("Object") for non-primitives.
       args: Array.isArray(e.args) && e.args.length
-        ? e.args.map((a) => a.value ?? a.type)
+        ? e.args.map((a) => (a.value !== undefined && typeof a.value !== 'object' ? a.value : a.type))
         : [e.text],
     });
   });
@@ -416,13 +445,20 @@ export async function runDaemon(opts, outputDir, initialUrl) {
       // Firefox/BiDi has no page.cdp — evaluate over BiDi in the active context.
       if (!page.cdp) {
         try {
-          // BiDi's raw result.value serializes objects into a {type,value}
-          // entries structure, not a plain object (CDP's returnByValue does).
-          // Stringify + parse in-page so an object/array eval matches the CDP
-          // shape (same trick readable() uses). `undefined` → JSON `null`.
-          const wrapped = `(async () => { const v = await (${expression}); return JSON.stringify(v === undefined ? null : v); })()`;
-          const raw = await page.bidi.evaluate(page.context, wrapped, true);
-          return { ok: true, value: raw == null ? null : JSON.parse(raw) };
+          // Evaluate the RAW expression: script.evaluate has eval-semantics, so
+          // statement lists ("var x = 2; x * 3") work and yield the completion
+          // value — matching the CDP Runtime.evaluate path. (An earlier
+          // `await (${expression})` wrapper flattened objects but broke every
+          // statement-form expression with a SyntaxError.) BiDi returns a
+          // {type,value} remote value; deserializeBiDi walks it back to the plain
+          // JS value CDP's returnByValue produces.
+          const res = await page.bidi.send('script.evaluate', {
+            expression, target: { context: page.context }, awaitPromise: true,
+          });
+          if (res.type === 'exception') {
+            return { ok: false, error: res.exceptionDetails?.text || 'eval error' };
+          }
+          return { ok: true, value: deserializeBiDi(res.result) };
         } catch (err) {
           return { ok: false, error: err.message || 'eval error' };
         }

--- a/src/firefox-page.js
+++ b/src/firefox-page.js
@@ -575,7 +575,14 @@ export async function createFirefoxPage(bidi, opts = {}) {
           secure: !!c.secure,
           httpOnly: !!c.httpOnly,
         };
-        if (c.sameSite && c.sameSite !== 'default') out.sameSite = c.sameSite;
+        // BiDi reports sameSite lowercase (strict|lax|none); the CDP saveState /
+        // Network.setCookies vocabulary is capitalized (Strict|Lax|None). The only
+        // loader for a state file is connect()'s storageState (CDP-only), which
+        // rejects a lowercase enum and silently drops every cookie — so capitalize
+        // here to keep the format truly symmetric and the round-trip working.
+        if (c.sameSite && c.sameSite !== 'default') {
+          out.sameSite = c.sameSite.charAt(0).toUpperCase() + c.sameSite.slice(1);
+        }
         if (c.expiry && c.expiry > 0) out.expires = c.expiry;
         return out;
       });

--- a/test/integration/firefox.test.js
+++ b/test/integration/firefox.test.js
@@ -568,7 +568,7 @@ describe('connect({ engine: firefox }) — saveState (Phase 4)', { skip: !hasFir
   let server, origin;
   before(async () => {
     server = createServer((_req, res) => {
-      res.writeHead(200, { 'set-cookie': 'sess=abc123; Path=/', 'content-type': 'text/html' });
+      res.writeHead(200, { 'set-cookie': 'sess=abc123; Path=/; SameSite=Lax', 'content-type': 'text/html' });
       res.end('<script>localStorage.setItem("token","xyz")</script>hello');
     });
     await new Promise((r) => server.listen(0, '127.0.0.1', r));
@@ -591,6 +591,9 @@ describe('connect({ engine: firefox }) — saveState (Phase 4)', { skip: !hasFir
       assert.ok(c, 'session cookie captured');
       assert.equal(c.value, 'abc123', 'cookie value flattened to a string');
       assert.equal(c.domain, '127.0.0.1');
+      // sameSite capitalized to CDP's vocabulary (Lax, not BiDi's 'lax') so the
+      // state file reloads via connect()'s CDP-only storageState loader.
+      assert.equal(c.sameSite, 'Lax', 'sameSite capitalized for CDP setCookies');
       assert.equal(state.localStorage.token, 'xyz', 'localStorage captured');
       // Owner-only — it holds session tokens (security invariant).
       assert.equal(statSync(file).mode & 0o777, 0o600, 'state file is 0600');

--- a/test/unit/daemon.test.js
+++ b/test/unit/daemon.test.js
@@ -11,7 +11,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildDaemonArgs, attachBiDiCapture } from '../../src/daemon.js';
+import { buildDaemonArgs, attachBiDiCapture, deserializeBiDi } from '../../src/daemon.js';
 
 const CLI = '/x/cli.js';
 
@@ -93,6 +93,17 @@ describe('attachBiDiCapture — Firefox console/network log capture', () => {
     });
     // Uncaught JS error: no console method, args often absent → fall back to level + text.
     bidi.emit('log.entryAdded', { type: 'javascript', level: 'error', text: 'ReferenceError: x' });
+    // Object/array args carry a nested {type,value} serialization — it must NOT
+    // be splatted into the log; fall back to the type name (CDP logs "Object").
+    bidi.emit('log.entryAdded', {
+      type: 'console', method: 'log', level: 'info',
+      args: [
+        { type: 'string', value: 'obj' },
+        { type: 'object', value: [['user', { type: 'string', value: 'x' }]] },
+        { type: 'array', value: [{ type: 'number', value: 1 }] },
+      ],
+      text: 'obj [object Object] 1',
+    });
 
     assert.equal(consoleLogs[0].type, 'warning', 'BiDi warn maps to CDP warning');
     assert.deepEqual(consoleLogs[0].args, ['hi', 42]);
@@ -100,6 +111,7 @@ describe('attachBiDiCapture — Firefox console/network log capture', () => {
     assert.deepEqual(consoleLogs[1].args, ['plain']);
     assert.equal(consoleLogs[2].type, 'error', 'javascript entry uses level');
     assert.deepEqual(consoleLogs[2].args, ['ReferenceError: x'], 'no args → [text]');
+    assert.deepEqual(consoleLogs[3].args, ['obj', 'object', 'array'], 'non-primitive args → type name, no nested dump');
   });
 
   it('pairs responseCompleted with its pending request', async () => {
@@ -145,5 +157,38 @@ describe('attachBiDiCapture — Firefox console/network log capture', () => {
     bidi.emit('network.responseCompleted', { request: { request: 'ghost' }, response: { status: 200 } });
     bidi.emit('network.fetchError', { request: { request: 'ghost2' }, errorText: 'x' });
     assert.equal(networkLogs.length, 0);
+  });
+});
+
+/**
+ * deserializeBiDi — turns a BiDi remote value ({type,value}) back into the plain
+ * JS value CDP's returnByValue yields, so `eval` returns the same shape on both
+ * engines. Guards the Firefox eval path (daemon 'eval' command) that replaced an
+ * `await (${expr})` wrapper which broke statement-form expressions.
+ */
+describe('deserializeBiDi', () => {
+  it('passes primitives through', () => {
+    assert.equal(deserializeBiDi({ type: 'number', value: 6 }), 6);
+    assert.equal(deserializeBiDi({ type: 'string', value: 'x' }), 'x');
+    assert.equal(deserializeBiDi({ type: 'boolean', value: true }), true);
+    assert.equal(deserializeBiDi({ type: 'null' }), null);
+    assert.equal(deserializeBiDi({ type: 'undefined' }), undefined);
+  });
+
+  it('reconstructs nested objects and arrays from entry lists', () => {
+    const remote = {
+      type: 'object',
+      value: [
+        ['user', { type: 'string', value: 'x' }],
+        ['n', { type: 'number', value: 1 }],
+        ['list', { type: 'array', value: [{ type: 'number', value: 2 }, { type: 'array', value: [{ type: 'number', value: 3 }] }] }],
+      ],
+    };
+    assert.deepEqual(deserializeBiDi(remote), { user: 'x', n: 1, list: [2, [3]] });
+  });
+
+  it('falls back to the type name for values with no plain equivalent', () => {
+    assert.equal(deserializeBiDi({ type: 'function' }), 'function');
+    assert.equal(deserializeBiDi({ type: 'date', value: '2020-01-01T00:00:00.000Z' }), '2020-01-01T00:00:00.000Z');
   });
 });


### PR DESCRIPTION
## Summary
Three validated fixes from a `/code-review medium` pass over the Firefox parity arc (v0.16.0–v0.19.1). Each was confirmed against **real Firefox** before fixing; two candidate findings were validated-but-declined (would regress).

- **`saveState` sameSite casing** — Firefox wrote BiDi's lowercase `lax`/`strict`/`none`, but the only loader (`connect({ storageState })`) is CDP-only and rejects a lowercase enum → the whole `Network.setCookies` batch threw and **every cookie was silently dropped**, making a Firefox-saved state useless for auth restore. Now capitalized to `Lax`/`Strict`/`None`.
- **Firefox `eval` statement regression** — a Phase-4 `await (${expr})` wrapper turned every statement list (`var x=2; x*3`) into a `SyntaxError`. Now evaluates the raw expression (BiDi `script.evaluate` has eval-semantics) + a new `deserializeBiDi()` walks the `{type,value}` remote value back to CDP's plain-value shape — statements work **and** deep objects stay clean.
- **Console object-arg formatting** — no longer splats nested `{type,value}` serialization into the daemon log; falls back to the type name (CDP-parity).

**Declined (validated, but fixing would regress):** premature network-idle on redirect (empty-pending window is microscopic; a 3xx-skip breaks manual/background 3xx) and download `savedPath` URL-mismatch (unreproduced).

## Verification
- `tsc --noEmit` → 0
- Tests **228/228** (unit 144 · browse+interact 31 · cli 20 · firefox 33)
- `/ship` Ready · `/security` clean · `/diff-review` Ready-to-merge
- Fixes verified end-to-end against real Firefox (POCs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)